### PR TITLE
Fixed issue when user single clicks without dragging after a SimpleShape draw handler is installed in the view

### DIFF
--- a/src/draw/shapes/SimpleShape.Draw.js
+++ b/src/draw/shapes/SimpleShape.Draw.js
@@ -50,15 +50,11 @@ L.SimpleShape.Draw = L.Handler.Draw.extend({
 
 	_onMouseMove: function (e) {
 		var layerPoint = e.layerPoint,
-			latlng = e.latlng;
+				latlng = e.latlng;
 
+		this._updateLabelPosition(layerPoint);
 		if (this._isDrawing) {
 			this._updateLabelText({ text: 'Release mouse to finish drawing.' });
-		}
-		this._updateLabelPosition(layerPoint);
-
-		if (this._isDrawing) {
-			this._updateLabelPosition(layerPoint);
 			this._drawShape(latlng);
 		}
 	},


### PR DESCRIPTION
If a SimpleShape draw handler is installed in the map and the user single clicks without dragging then the following exception is thrown: `Uncaught TypeError: 'Cannot call method 'getRadius' of undefined'` by the `_fireCreatedEvent` method of Circle and Rectangle. The _fireCreatedEvent method creates a new Leaflet shape using the _shape variable created in the _drawShape method but the _drawShape method is only called when the mouse is moved.
You could create a shape with no area if the mouse is not moved after clicking but I thought it made more sense to just not fire the created event if the mouse is single clicked.
Also moved the update to the label text into _onMouseMove so that the label text doesn't change if the user single clicks on the map.
