### PR TITLE
Move handlers object out of L.Control.Draw's prototype

### DIFF
--- a/src/draw/Control.Draw.js
+++ b/src/draw/Control.Draw.js
@@ -23,8 +23,6 @@ L.Control.Draw = L.Control.extend({
 		}
 	},
 
-	handlers: {},
-	
 	initialize: function (options) {
 		L.Util.extend(this.options, options);
 	},
@@ -32,7 +30,9 @@ L.Control.Draw = L.Control.extend({
 	onAdd: function (map) {
 		var className = 'leaflet-control-draw',
 			container = L.DomUtil.create('div', className);
-
+	
+		this.handlers = {};
+	
 		if (this.options.polyline) {
 			this.handlers.polyline = new L.Polyline.Draw(map, this.options.polyline);
 			this._createButton(


### PR DESCRIPTION
refs #36 - Move handlers object out of L.Control.Draw's prototype to avoid config clashes between instances.
