### PR TITLE
Allow markers to be draggable immediately

### DIFF
--- a/src/draw/shapes/Marker.Draw.js
+++ b/src/draw/shapes/Marker.Draw.js
@@ -56,7 +56,7 @@ L.Marker.Draw = L.Handler.Draw.extend({
 	_onClick: function (e) {
 		this._map.fire(
 			'draw:marker-created',
-			{ marker: new L.Marker(this._marker.getLatLng(), { icon: this.options.icon }) }
+			{ marker: new L.Marker(this._marker.getLatLng(), { icon: this.options.icon, draggable: this.options.draggable }) }
 		);
 		this.disable();
 	}


### PR DESCRIPTION
When adding new markers to the map, it makes sense to allow the marker to be draggable after it has been places (the user might want to give a more precise location). I'm aware that 0.2 branch has a new "edit mode" to handle this feature, but still I think it's a natural option to be present in a plugin like this.
