### PR TITLE
consistent event for shape creation

### DIFF
--- a/src/draw/Handler.Draw.js
+++ b/src/draw/Handler.Draw.js
@@ -46,7 +46,11 @@ L.Handler.Draw = L.Handler.extend({
 			L.DomEvent.removeListener(this._container, 'keyup', this._cancelDrawing);
 		}
 	},
-
+            _onFinishShape: function(shape) {
+                        this._map.fire(
+		          'draw:created',
+		          {shape: shape,type: this.type})  
+            },
 	_updateLabelText: function (labelText) {
 		labelText.subtext = labelText.subtext || '';
 

--- a/src/draw/shapes/Circle.Draw.js
+++ b/src/draw/shapes/Circle.Draw.js
@@ -26,9 +26,10 @@ L.Circle.Draw = L.SimpleShape.Draw.extend({
 	},
 
 	_fireCreatedEvent: function () {
-		this._map.fire(
-			'draw:circle-created',
+	           this._onFinishShape(new L.Circle(this._startLatLng, this._shape.getRadius(), this.options.shapeOptions));
+		/*this._map.fire(
+		          	'draw:circle-created',
 			{ circ: new L.Circle(this._startLatLng, this._shape.getRadius(), this.options.shapeOptions) }
-		);
+		);*/
 	}
 });

--- a/src/draw/shapes/Marker.Draw.js
+++ b/src/draw/shapes/Marker.Draw.js
@@ -54,10 +54,11 @@ L.Marker.Draw = L.Handler.Draw.extend({
 	},
 
 	_onClick: function (e) {
-		this._map.fire(
+	           this._onFinishShape(new L.Marker(this._marker.getLatLng(), { icon: this.options.icon }));
+		/*this._map.fire(
 			'draw:marker-created',
 			{ marker: new L.Marker(this._marker.getLatLng(), { icon: this.options.icon }) }
-		);
+		);*/
 		this.disable();
 	}
 });

--- a/src/draw/shapes/Polyline.Draw.js
+++ b/src/draw/shapes/Polyline.Draw.js
@@ -105,11 +105,11 @@ L.Polyline.Draw = L.Handler.Draw.extend({
 			this._showErrorLabel();
 			return;
 		}
-
-		this._map.fire(
-			'draw:poly-created',
+                    this._onFinishShape(new this.Poly(this._poly.getLatLngs(), this.options.shapeOptions))
+		/*this._map.fire(
+		          'draw:poly-created',
 			{ poly: new this.Poly(this._poly.getLatLngs(), this.options.shapeOptions) }
-		);
+		)*/;
 		this.disable();
 	},
 

--- a/src/draw/shapes/Rectangle.Draw.js
+++ b/src/draw/shapes/Rectangle.Draw.js
@@ -26,9 +26,10 @@ L.Rectangle.Draw = L.SimpleShape.Draw.extend({
 	},
 
 	_fireCreatedEvent: function () {
-		this._map.fire(
+	           this._onFinishShape( new L.Rectangle(this._shape.getBounds(), this.options.shapeOptions));
+		/*this._map.fire(
 			'draw:rectangle-created',
 			{ rect: new L.Rectangle(this._shape.getBounds(), this.options.shapeOptions) }
-		);
+		);*/
 	}
 });


### PR DESCRIPTION
Hi,
Thanks a lot for this quality plugin ; ) 

This request would allow a more consistent scheme for event handling once a shape is created. 

For instance, in the example file, instead of having 4 handling functions for each shape created like:

``` js
var drawnItems = new L.LayerGroup();
        map.on('draw:poly-created', function (e) {
            drawnItems.addLayer(e.poly);
        });
        map.on('draw:rectangle-created', function (e) {
            drawnItems.addLayer(e.rect);
        });
        map.on('draw:circle-created', function (e) {
            drawnItems.addLayer(e.circ);
        });
        map.on('draw:marker-created', function (e) {
            e.marker.bindPopup('A popup!');
            drawnItems.addLayer(e.marker);
        });
```

you could jus use: 

``` js
map.on('draw:created', function (e) { // e being an object {shape: theShape, type: its type}
                       if(e.type == 'maker') {
                           e.shape.bindPopup('A popup!');
                           }
               drawnItems.addLayer(e.shape);
        });

```

cheers, 
C.
