### PR TITLE
Sanity check of buttons length before calling indexes

### DIFF
--- a/src/draw/Control.Draw.js
+++ b/src/draw/Control.Draw.js
@@ -96,9 +96,11 @@ L.Control.Draw = L.Control.extend({
 			this.handlers.marker.on('activated', this._disableInactiveModes, this);
 		}
 		
-		// Add in the top and bottom classes so we get the border radius
-		L.DomUtil.addClass(buttons[0], partName + '-top');
-		L.DomUtil.addClass(buttons[buttons.length - 1], partName + '-bottom');
+		if (buttons.length) {
+			// Add in the top and bottom classes so we get the border radius
+			L.DomUtil.addClass(buttons[0], partName + '-top');
+			L.DomUtil.addClass(buttons[buttons.length - 1], partName + '-bottom');
+		}
 
 		return container;
 	},


### PR DESCRIPTION
My use case is that enabling/disabling handlers can be done from UI by users in [Leaflet.Storage](https://github.com/yohanboniface/Leaflet.Storage) (demo [here](http://umap.fluv.io/)), so one can disable all the handlers.
I also can do some checks on my side, but: 1. I think this sanity check doesn't cost; 2. I'm using the container even if no handler is enabled.

Thanks!

Yohan
