### PR TITLE
Adds markerOffset option to L.Marker.Draw

### DIFF
--- a/src/draw/shapes/Marker.Draw.js
+++ b/src/draw/shapes/Marker.Draw.js
@@ -3,7 +3,8 @@ L.Marker.Draw = L.Handler.Draw.extend({
 
 	options: {
 		icon: new L.Icon.Default(),
-		zIndexOffset: 2000 // This should be > than the highest z-index any markers
+		zIndexOffset: 2000, // This should be > than the highest z-index any markers
+		markerOffset: null
 	},
 	
 	addHooks: function () {
@@ -33,12 +34,19 @@ L.Marker.Draw = L.Handler.Draw.extend({
 
 	_onMouseMove: function (e) {
 		var newPos = e.layerPoint,
-			latlng = e.latlng;
+			latlng = e.latlng,
+			offsetLatlng = e.latlng;
+
+		if (this.options.markerOffset) {
+			offsetLatlng = this._map.unproject(
+				this._map.project(latlng).add(this.options.markerOffset)
+			);
+		}
 
 		this._updateLabelPosition(newPos);
 
 		if (!this._marker) {
-			this._marker = new L.Marker(latlng, {
+			this._marker = new L.Marker(offsetLatlng, {
 				icon: this.options.icon,
 				zIndexOffset: this.options.zIndexOffset
 			});
@@ -49,7 +57,7 @@ L.Marker.Draw = L.Handler.Draw.extend({
 				.addLayer(this._marker);
 		}
 		else {
-			this._marker.setLatLng(latlng);
+			this._marker.setLatLng(offsetLatlng);
 		}
 	},
 


### PR DESCRIPTION
When placing a marker with L.Marker.Draw, the tip of the marker follows the mouse cursor's position.  I wanted the tip of the mouse cursor to be closer to the top of the marker similar to how a user would naturally drag a marker around.  It would also solve a problem I was having where I couldn't get clicks to make it through to the map because of things I had in the way. 

So I added a markerOffset option to L.Marker.Draw.  By default, there is no offset and the previous behavior is preserved.  But when markerOffset is set to an instance of L.Point, it uses the point's x and y values as offsets for the marker from the cursor.  For example, ```new L.Marker.Draw(map, {markerOffset: new L.Point(0,28)});``` makes the mouse cursor sit at about the white circle in the center of the default Leaflet marker image as you hover around with it.  On click, the location that the 'draw:marker-created' event contains is where the tip of the marker was when the click happened (same as always).