### PR TITLE
Fixes #77; adds option to disable middle edit markers

### DIFF
--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -7,6 +7,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 
 	options: {
 		allowIntersection: true,
+		allowMiddleMarkers: true,
 		drawError: {
 			color: '#b00b00',
 			message: '<strong>Error:</strong> shape edges cannot cross!',
@@ -48,6 +49,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 			this._markerGroup = new L.LayerGroup();
 			this._map.addLayer(this._markerGroup);
 
+			this.options.shapeOptions.allowMiddleMarkers = this.options.allowMiddleMarkers;
 			this._poly = new L.Polyline([], this.options.shapeOptions);
 
 			this._tooltip.updateContent(this._getTooltipText());

--- a/src/edit/handler/Edit.Poly.js
+++ b/src/edit/handler/Edit.Poly.js
@@ -51,7 +51,6 @@ L.Edit.Poly = L.Handler.extend({
 		// TODO refactor holes implementation in Polygon to support it here
 
 		for (i = 0, len = latlngs.length; i < len; i++) {
-
 			marker = this._createMarker(latlngs[i], i);
 			marker.on('click', this._onMarkerClick, this);
 			this._markers.push(marker);
@@ -104,7 +103,7 @@ L.Edit.Poly = L.Handler.extend({
 		if (marker._middleRight) {
 			marker._middleRight.setLatLng(this._getMiddleLatLng(marker, marker._next));
 		}
-
+		
 		this._poly.redraw();
 	},
 
@@ -155,6 +154,10 @@ L.Edit.Poly = L.Handler.extend({
 	},
 
 	_createMiddleMarker: function (marker1, marker2) {
+		if (this._poly.options.allowMiddleMarkers === false) {
+			return;
+		}
+		
 		var latlng = this._getMiddleLatLng(marker1, marker2),
 		    marker = this._createMarker(latlng),
 		    onClick,


### PR DESCRIPTION
Simply do the following when initiating the draw control:

```
var drawControl = new L.Control.Draw({
    draw: {
        polyline: {
            allowMiddleMarkers: false
        }
    }
);
```
