### PR TITLE
doubleclick close support for polygons, #50

### DIFF
--- a/src/draw/handler/Draw.Polygon.js
+++ b/src/draw/handler/Draw.Polygon.js
@@ -52,6 +52,11 @@ L.Draw.Polygon = L.Draw.Polyline.extend({
 
 	_vertexAdded: function () {
 		//calc area here
+		var marker_amount = this._markers.length;
+		if (marker_amount >= 3) {
+			this._markers[marker_amount-2].off('dblclick', this._finishShape, this);
+			this._markers[marker_amount-1].on('dblclick', this._finishShape, this);
+		}
 	},
 
 	_cleanUpShape: function () {


### PR DESCRIPTION
Using Leaflet's built in doubleclick support.

References issue #50
