### PR TITLE
Use FeatureGroup rather than LayerGroup in Polyline

### DIFF
--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -45,8 +45,8 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 		if (this._map) {
 			this._markers = [];
 
-			this._markerGroup = new L.LayerGroup();
-			this._markerGroup.addTo(this._map);
+			this._markerGroup = new L.FeatureGroup();
+			this._map.addLayer(this._markerGroup);
 
 			this._poly = new L.Polyline([], this.options.shapeOptions);
 


### PR DESCRIPTION
Main purpose is compatibility with mapbox.  See open issue [here](https://github.com/mapbox/mapbox.js/issues/372).
