### PR TITLE
Allow to disable handlers again

### DIFF
--- a/src/draw/DrawToolbar.js
+++ b/src/draw/DrawToolbar.js
@@ -22,7 +22,9 @@ L.DrawToolbar = L.Toolbar.extend({
 		// Ensure that the options are merged correctly since L.extend is only shallow
 		for (var type in this.options) {
 			if (this.options.hasOwnProperty(type)) {
-				options[type] = L.extend({}, this.options[type], options[type]);
+				if (options[type]) {
+					options[type] = L.extend({}, this.options[type], options[type]);
+				}
 			}
 		}
 


### PR DESCRIPTION
I think this was broken in d1347433fde0b25290c3c287ab743faeba6b0596.

What do you think?

About implementation, I can also do a `if(hasOwnProp(type) && options[type])`, instead of two `if`, if you prefer.

Thanks!

Yohan
