### PR TITLE
Update README.md to require Leaflet 0.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Important
-You will need to download the latest Leaflet from master in the [Github repo](https://github.com/Leaflet/Leaflet) before Leaflet.draw 0.2.0 will work.
+Leaflet.draw 0.2.0 requires [Leaflet 0.6](https://github.com/Leaflet/Leaflet/archive/v0.6.zip) or higher.
 
 #Leaflet.draw
 Adds support for drawing and editing vectors and markers on [Leaflet maps](https://github.com/Leaflet/Leaflet). Check out the [demo](http://leaflet.github.com/Leaflet.draw/)


### PR DESCRIPTION
Require Leaflet 0.6 and link to downloadable .zip.
