### PR TITLE
Buttons horizontal size was hardcoded in JS (fix #180)

### DIFF
--- a/dist/leaflet.draw.css
+++ b/dist/leaflet.draw.css
@@ -58,7 +58,7 @@
 }
 
 .leaflet-draw-actions li {
-	float: left;
+	display: inline-block;
 }
 
 .leaflet-draw-actions li:first-child a {
@@ -87,7 +87,8 @@
 	font: 11px/19px "Helvetica Neue", Arial, Helvetica, sans-serif;
 	line-height: 28px;
 	text-decoration: none;
-	width: 50px;
+	padding-left: 10px;
+	padding-right: 10px;
 	height: 28px;
 }
 
@@ -97,6 +98,7 @@
 
 .leaflet-draw-actions-top {
 	margin-top: 1px;
+	white-space: nowrap;
 }
 
 .leaflet-draw-actions-top a,

--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -128,7 +128,6 @@ L.Toolbar = L.Class.extend({
 		var container = L.DomUtil.create('ul', 'leaflet-draw-actions'),
 			buttonWidth = 50,
 			l = buttons.length,
-			containerWidth = (l * buttonWidth) + (l - 1), //l - 1 = the borders
 			li, button;
 
 		for (var i = 0; i < l; i++) {
@@ -147,8 +146,6 @@ L.Toolbar = L.Class.extend({
 				callback: buttons[i].callback
 			});
 		}
-
-		container.style.width = containerWidth + 'px';
 
 		return container;
 	},


### PR DESCRIPTION
It uses 'display: inline-block' css property so it should not work on IE6/7 (as I didn't tested it I couldn't provide a conditional alternative, i'll do it later if pr is ok).
So, buttons can now contain any text length (for i18n) without breaking.
