### PR TITLE
Check for icon existence before disabling edit state

### DIFF
--- a/src/edit/handler/EditToolbar.Edit.js
+++ b/src/edit/handler/EditToolbar.Edit.js
@@ -135,9 +135,9 @@ L.EditToolbar.Edit = L.Handler.extend({
 	},
 
 	_toggleMarkerHighlight: function (marker) {
-        if (!marker._icon) {
-            return;
-        }
+		if (!marker._icon) {
+			return;
+		}
 		// This is quite naughty, but I don't see another way of doing it. (short of setting a new icon)
 		var icon = marker._icon;
 


### PR DESCRIPTION
Fixes #172 by exiting early from `_toggleMarkerHighlight` if the marker's icon is not present.
