### PR TITLE
Only update guideslines when guidelines are present

### DIFF
--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -208,11 +208,11 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 	},
 
 	_updateGuide: function (newPos) {
-		newPos = newPos || this._map.latLngToLayerPoint(this._currentLatLng);
-
 		var markerCount = this._markers.length;
 
 		if (markerCount > 0) {
+			newPos = newPos || this._map.latLngToLayerPoint(this._currentLatLng);
+			
 			// draw the guide line
 			this._clearGuides();
 			this._drawGuide(


### PR DESCRIPTION
This fix eliminates a spurious stacktrace that results when the map is zoomed programmatically before the mousemove event fires and defines the _currentLatLng property.
