### PR TITLE
showLength for polylines and showRadius for circles

### DIFF
--- a/src/draw/handler/Draw.Circle.js
+++ b/src/draw/handler/Draw.Circle.js
@@ -14,6 +14,7 @@ L.Draw.Circle = L.Draw.SimpleShape.extend({
 			fillOpacity: 0.2,
 			clickable: true
 		},
+		showRadius: true,
 		metric: true // Whether to use the metric meaurement system or imperial
 	},
 
@@ -54,7 +55,7 @@ L.Draw.Circle = L.Draw.SimpleShape.extend({
 
 			this._tooltip.updateContent({
 				text: this._endLabelText,
-				subtext: 'Radius: ' + L.GeometryUtil.readableDistance(radius, this.options.metric)
+				subtext: this.options.showRadius ? 'Radius: ' + L.GeometryUtil.readableDistance(radius, this.options.metric) : ''
 			});
 		}
 	}

--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -26,6 +26,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 			clickable: true
 		},
 		metric: true, // Whether to use the metric meaurement system or imperial
+		showLength: true, // Whether to display distance in the tooltip
 		zIndexOffset: 2000 // This should be > than the highest z-index any map layers
 	},
 
@@ -293,7 +294,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 				text: L.drawLocal.draw.handlers.polyline.tooltip.start
 			};
 		} else {
-			distanceStr = this._getMeasurementString();
+			distanceStr = this.options.showLength ? this._getMeasurementString() : '';
 
 			if (this._markers.length === 1) {
 				labelText = {


### PR DESCRIPTION
`Draw.Polygon` handler has `showArea` property which is turned off by default (!). This pull request adds similar options for circles and polylines, though they are turned on by default to maintain backwards compatibility.
