### PR TITLE
Fix bottom draw options display

### DIFF
--- a/dist/leaflet.draw.css
+++ b/dist/leaflet.draw.css
@@ -94,6 +94,7 @@
 
 .leaflet-draw-actions-bottom {
 	margin-top: 0;
+	white-space: nowrap;
 }
 
 .leaflet-draw-actions-top {


### PR DESCRIPTION
The menu to save and cancel the action on vertical menu to delete layer was displayed in two lines. I fixed this problem adding a style line to css.
