### PR TITLE
Leave at least 3 points in a polygon

### DIFF
--- a/src/edit/handler/Edit.Poly.js
+++ b/src/edit/handler/Edit.Poly.js
@@ -125,7 +125,7 @@ L.Edit.Poly = L.Handler.extend({
 
 	_onMarkerClick: function (e) {
 		// we want to remove the marker on click, but if latlng count < 3, polyline would be invalid
-		if (this._poly._latlngs.length < 3) { return; }
+		if (this._poly._latlngs.length < (L.Polygon && (this._poly instanceof L.Polygon) ? 4 : 3)) { return; }
 
 		var marker = e.target;
 


### PR DESCRIPTION
It is possible in edit mode to remove all but two nodes in a polygon, leaving it essentially a line. This commit fixes that, ensuring a polygon has at least three nodes.
