### PR TITLE
EditToolbar now sets it's state correctly

### DIFF
--- a/src/edit/EditToolbar.js
+++ b/src/edit/EditToolbar.js
@@ -123,13 +123,14 @@ L.EditToolbar = L.Toolbar.extend({
 
 	_checkDisabled: function () {
 		var featureGroup = this.options.featureGroup,
-			hasLayers = featureGroup.getLayers().length === 0,
+			hasLayers = featureGroup.getLayers().length !== 0,
 			button;
 
 		if (this.options.edit) {
 			button = this._modes[L.EditToolbar.Edit.TYPE].button;
 
-			L.DomUtil.toggleClass(button, 'leaflet-disabled');
+			if (hasLayers) { L.DomUtil.removeClass(button, 'leaflet-disabled'); }
+			else { L.DomUtil.addClass(button, 'leaflet-disabled'); }
 
 			button.setAttribute(
 				'title',
@@ -142,7 +143,8 @@ L.EditToolbar = L.Toolbar.extend({
 		if (this.options.remove) {
 			button = this._modes[L.EditToolbar.Delete.TYPE].button;
 
-			L.DomUtil.toggleClass(button, 'leaflet-disabled');
+			if (hasLayers) { L.DomUtil.removeClass(button, 'leaflet-disabled'); }
+			else { L.DomUtil.addClass(button, 'leaflet-disabled'); }
 
 			button.setAttribute(
 				'title',


### PR DESCRIPTION
Properly determines if it has layers, and then sets the button's disabled class.

fixes #202
