### PR TITLE
Use current mouse marker latlng

### DIFF
--- a/src/draw/handler/Draw.Marker.js
+++ b/src/draw/handler/Draw.Marker.js
@@ -81,6 +81,7 @@ L.Draw.Marker = L.Draw.Feature.extend({
 				.addLayer(this._marker);
 		}
 		else {
+			latlng = this._mouseMarker.getLatLng();
 			this._marker.setLatLng(latlng);
 		}
 	},


### PR DESCRIPTION
We should make sure to use the latest mouse marker position, in case current mouse marker has been snapped for example.

Reference : See drawing marker here : http://makinacorpus.github.io/Leaflet.Snap/
