### PR TITLE
Do not share options between Draw.Feature instances

### DIFF
--- a/src/draw/handler/Draw.Feature.js
+++ b/src/draw/handler/Draw.Feature.js
@@ -13,7 +13,7 @@ L.Draw.Feature = L.Handler.extend({
 		if (options && options.shapeOptions) {
 			options.shapeOptions = L.Util.extend({}, this.options.shapeOptions, options.shapeOptions);
 		}
-		L.Util.extend(this.options, options);
+		L.setOptions(this, options);
 	},
 
 	enable: function () {


### PR DESCRIPTION
Extending `this.options` in place makes the object shared between every instances of L.Draw.Feature.

This change prevents this behaviour.

I don't think this was intentional, and in my understanding of Leaflet conventions, `statics` are made for being shared, not `options`.

My use case is to add a measure tool on uMap using Leaflet.draw, while I also use the plugin for classic drawing on the map.

Thanks!

Yohan
