### PR TITLE
Fix trailing comma in package.json that was making npm install fail.

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "happen": "~0.1.3",
     "karma": "~0.10.4",
     "karma-mocha": "~0.1.0",
-    "karma-coverage": "~0.1.3",
+    "karma-coverage": "~0.1.3"
   },
   "main": "dist/leaflet.draw.js",
   "directories": {


### PR DESCRIPTION
The trailing comma in the package.json is making npm have a parse error when running npm install.
