### PR TITLE
fix package.json json format

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "happen": "~0.1.3",
     "karma": "~0.10.4",
     "karma-mocha": "~0.1.0",
-    "karma-coverage": "~0.1.3",
+    "karma-coverage": "~0.1.3"
   },
   "main": "dist/leaflet.draw.js",
   "directories": {


### PR DESCRIPTION
This commit makes a fis to this error:

```
npm ERR! Failed to parse json
npm ERR! Unexpected token }
npm ERR! File: /home/pvalleri/src/Leaflet.draw.ilvalle/package.json
npm ERR! Failed to parse package.json data.
npm ERR! package.json must be actual JSON, not just JavaScript.
npm ERR! 
npm ERR! This is not a bug in npm.
npm ERR! Tell the package author to fix their package.json file. JSON.parse
```
