### PR TITLE
fix leaflet path in karma.conf.js

### DIFF
--- a/spec/karma.conf.js
+++ b/spec/karma.conf.js
@@ -2,10 +2,10 @@
 module.exports = function (config) {
 
 	var libSources = require(__dirname+'/../build/build.js').getFiles();
-	var leafletSources = require(__dirname+'/../node_modules/Leaflet/build/build.js').getFiles();
+	var leafletSources = require(__dirname+'/../node_modules/leaflet/build/build.js').getFiles();
 
 	for (var i=0; i < leafletSources.length; i++) {
-		leafletSources[i] = __dirname+"/../node_modules/Leaflet/" + leafletSources[i];
+		leafletSources[i] = __dirname+"/../node_modules/leaflet/" + leafletSources[i];
 	}
 
 	var files = [


### PR DESCRIPTION
this commit makes a fit to the following issue:

```
pvalleri@paolo-ThinkPad-T431s ~/src/Leaflet.draw.ilvalle[master]$ jake
Checking for JS errors...
    Check passed.

Checking for specs JS errors...
    Check passed.

Running tests...

ERROR [config]: Error in config file!
 { [Error: Cannot find module '/home/pvalleri/src/Leaflet.draw.ilvalle/spec/../node_modules/Leaflet/build/build.js'] code: 'MODULE_NOT_FOUND' }
Error: Cannot find module '/home/pvalleri/src/Leaflet.draw.ilvalle/spec/../node_modules/Leaflet/build/build.js'
    at Function.Module._resolveFilename (module.js:338:15)
    at Function.Module._load (module.js:280:25)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at module.exports (/home/pvalleri/src/Leaflet.draw.ilvalle/spec/karma.conf.js:5:23)
    at Object.parseConfig (/home/pvalleri/src/Leaflet.draw.ilvalle/node_modules/karma/lib/config.js:335:5)
    at Object.exports.start (/home/pvalleri/src/Leaflet.draw.ilvalle/node_modules/karma/lib/server.js:178:20)
    at Object.exports.test (/home/pvalleri/src/Leaflet.draw.ilvalle/build/build.js:181:15)
    at null.action (/home/pvalleri/src/Leaflet.draw.ilvalle/Jakefile.js:41:11)
    at TaskBase.run (/usr/local/lib/node_modules/jake/lib/task/task.js:199:27)
    at TaskBase.handlePrereqComplete (/usr/local/lib/node_modules/jake/lib/task/task.js:181:12)
    at null.<anonymous> (/usr/local/lib/node_modules/jake/lib/task/task.js:149:16)
    at g (events.js:175:14)
    at EventEmitter.emit (events.js:95:17)
    at TaskBase.complete (/usr/local/lib/node_modules/jake/lib/task/task.js:243:10)
    at api.complete (/usr/local/lib/node_modules/jake/lib/api.js:287:15)
    at null._callback (/home/pvalleri/src/Leaflet.draw.ilvalle/Jakefile.js:23:13)
    at utils.mixin._run (/usr/local/lib/node_modules/jake/lib/utils/index.js:222:18)
    at ChildProcess.<anonymous> (/usr/local/lib/node_modules/jake/lib/utils/index.js:214:20)
    at ChildProcess.EventEmitter.emit (events.js:98:17)
    at Process.ChildProcess._handle.onexit (child_process.js:789:12)

```
