### PR TITLE
Show/hide buttons (first draft)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,10 @@ pip-log.txt
 
 # Mac crap
 .DS_Store
+
+#################
+## Sublime text
+#################
+
+*.sublime-project
+*.sublime-workspace

--- a/dist/leaflet.draw.css
+++ b/dist/leaflet.draw.css
@@ -38,6 +38,11 @@
 	text-decoration: none;
 }
 
+.leaflet-container .leaflet-draw-hidden{
+	display: none;
+	visibility: hidden;
+}
+
 /* ================================================================== */
 /* Toolbar actions menu
 /* ================================================================== */

--- a/src/Control.Draw.js
+++ b/src/Control.Draw.js
@@ -69,6 +69,22 @@ L.Control.Draw = L.Control.extend({
 			}
 		}
 	},
+	
+	showButton: function (type, toggleClass) {
+		this._toggleButton({
+			showing: true,
+			type: type,
+			toggleClass: toggleClass // class to remove to show the element
+		});
+	},
+
+	hideButton: function (type, toggleClass) {
+		this._toggleButton({
+			showing: false,
+			type: type,
+			toggleClass: toggleClass // class to add to hide the element
+		});
+	},
 
 	setDrawingOptions: function (options) {
 		for (var toolbarId in this._toolbars) {
@@ -84,6 +100,17 @@ L.Control.Draw = L.Control.extend({
 		for (var toolbarId in this._toolbars) {
 			if (this._toolbars.hasOwnProperty(toolbarId) && toolbarId !== id) {
 				this._toolbars[toolbarId].disable();
+			}
+		}
+	},
+
+	_toggleButton: function (options) {
+		// loop over the toolbars to find the right buttons
+		for (var toolbarId in this._toolbars) {
+			if (this._toolbars.hasOwnProperty(toolbarId)) {
+				if(this._toolbars[toolbarId].toggleButton){
+					this._toolbars[toolbarId]._toggleButton(options);
+				}
 			}
 		}
 	}

--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -172,6 +172,53 @@ L.Toolbar = L.Class.extend({
 		this._actionsContainer.style.display = 'block';
 	},
 
+	_toggleButton: function (options) {
+		var toggleList = [],
+			showing = options.showing,
+			type = options.type,
+			toggleClass = options.toggleClass || 'leaflet-draw-hidden',
+			modes = this._modes,
+			addToToggleList = function (id) {
+				if(modes[id]){
+					toggleList.push(modes[id].button);
+				}
+			};
+
+		if (typeof type === 'undefined'){
+			// all buttons
+			for (var handlerId in this._modes) {
+				if (this._modes.hasOwnProperty(handlerId)) {
+					addToToggleList(handlerId);
+				}
+			}
+
+		} else if (typeof type === 'string'){
+			// one button
+			addToToggleList(type);
+
+		} else if (L.Util.isArray(type)){
+			// array of buttons
+			for (var handlerId in type){
+				if (type.hasOwnProperty(handlerId)) {
+					addToToggleList(type[handlerId]);
+				}
+			}
+		}
+
+		for (var id in toggleList){
+			if (toggleList.hasOwnProperty(id)) {
+				var button = toggleList[id];
+				
+				if(showing){
+					L.DomUtil.removeClass(button, toggleClass);
+
+				} else {
+					L.DomUtil.addClass(button, toggleClass);
+				}
+			}
+		}
+	},
+
 	_hideActionsToolbar: function () {
 		this._actionsContainer.style.display = 'none';
 


### PR DESCRIPTION
# Added two public methods to the draw controller.

``` javascript
drawControl.hideButton();
drawControl.showButton();
```

They have two parameters.
First param is the button type: polyline, polygon, rectangle, circle, marker, edit, etc.
Second param is the class name to use to show/hide, otherwise it uses 'leaflet-draw-hidden'.
## Show or hide all buttons

``` javascript
drawControl.hideButton();
drawControl.showButton();
drawControl.hideButton(undefined, 'hidden');
drawControl.showButton(undefined, 'hidden');
```
## Show or hide one buttons

``` javascript
drawControl.hideButton('circle');
drawControl.showButton('circle'));
drawControl.hideButton('circle'), 'hidden');
drawControl.showButton('circle'), 'hidden');
```
## Show or hide more buttons

``` javascript
drawControl.hideButton(['circle', 'marker']);
drawControl.showButton(['circle', 'marker']));
drawControl.hideButton(['circle', 'marker']), 'hidden');
drawControl.showButton(['circle', 'marker']), 'hidden');
```
