### PR TITLE
Fire event 'editstart' on shape edit

### DIFF
--- a/src/edit/handler/Edit.Poly.js
+++ b/src/edit/handler/Edit.Poly.js
@@ -199,6 +199,8 @@ L.Edit.Poly = L.Handler.extend({
 			marker2._index++;
 			this._updatePrevNext(marker1, marker);
 			this._updatePrevNext(marker, marker2);
+
+			this._poly.fire('editstart');
 		};
 
 		onDragEnd = function () {

--- a/src/edit/handler/Edit.SimpleShape.js
+++ b/src/edit/handler/Edit.SimpleShape.js
@@ -100,6 +100,8 @@ L.Edit.SimpleShape = L.Handler.extend({
 	_onMarkerDragStart: function (e) {
 		var marker = e.target;
 		marker.setOpacity(0);
+
+		this._shape.fire('editstart');
 	},
 
 	_fireEdit: function () {


### PR DESCRIPTION
Fire event `editstart` (complementing the `edit` event) when user starts modifying the shape.
