### PR TITLE
(1 of 1) Make layers deleteable before fireing draw:deletestart event

### DIFF
--- a/src/edit/handler/EditToolbar.Delete.js
+++ b/src/edit/handler/EditToolbar.Delete.js
@@ -28,13 +28,13 @@ L.EditToolbar.Delete = L.Handler.extend({
 		this.fire('enabled', { handler: this.type});
 			//this disable other handlers
 
+        L.Handler.prototype.enable.call(this);
+        this._deletableLayers
+            .on('layeradd', this._enableLayerDelete, this)
+            .on('layerremove', this._disableLayerDelete, this);
+
 		this._map.fire('draw:deletestart', { handler: this.type });
 			//allow drawLayer to be updated before beginning deletion.
-
-		L.Handler.prototype.enable.call(this);
-		this._deletableLayers
-			.on('layeradd', this._enableLayerDelete, this)
-			.on('layerremove', this._disableLayerDelete, this);
 	},
 
 	disable: function () {


### PR DESCRIPTION
Commit bb4d474 broke some code I had that was bound to the draw:deletestart event when it re-ordered the code to fire the event before the layers were made delete-able.

I reverted this change and submitted the pull request because it isn't clear from the commit why this was done?

@manubb what is problematic with the original ordering? Can it be reverted back to the original ordering (this commit)? Thanks!
