### PR TITLE
Proper resize cursors for simple shapes' resize markers in edit mode

### DIFF
--- a/dist/leaflet.draw.css
+++ b/dist/leaflet.draw.css
@@ -289,8 +289,12 @@
 	cursor: move;
 }
 
-.leaflet-edit-resize {
-	cursor: pointer;
+.leaflet-edit-resize-nesw {
+	cursor: nesw-resize;
+}
+
+.leaflet-edit-resize-nwse {
+	cursor: nwse-resize;
 }
 
 /* ================================================================== */

--- a/src/edit/handler/Edit.Rectangle.js
+++ b/src/edit/handler/Edit.Rectangle.js
@@ -9,12 +9,16 @@ L.Edit.Rectangle = L.Edit.SimpleShape.extend({
 	},
 
 	_createResizeMarker: function () {
-		var corners = this._getCorners();
+		var corners = this._getCorners(),
+		options;
 
 		this._resizeMarkers = [];
 
 		for (var i = 0, l = corners.length; i < l; i++) {
-			this._resizeMarkers.push(this._createMarker(corners[i], this.options.resizeIcon));
+			// Choose options depending on corner position; NW goes first
+			options = i % 2 === 0 ? this.options.nwseResizeIcon : this.options.resizeIcon;
+
+			this._resizeMarkers.push(this._createMarker(corners[i], options));
 			// Monkey in the corner index as we will need to know this for dragging
 			this._resizeMarkers[i]._cornerIndex = i;
 		}

--- a/src/edit/handler/Edit.SimpleShape.js
+++ b/src/edit/handler/Edit.SimpleShape.js
@@ -8,7 +8,11 @@ L.Edit.SimpleShape = L.Handler.extend({
 		}),
 		resizeIcon: new L.DivIcon({
 			iconSize: new L.Point(8, 8),
-			className: 'leaflet-div-icon leaflet-editing-icon leaflet-edit-resize'
+			className: 'leaflet-div-icon leaflet-editing-icon leaflet-edit-resize-nesw'
+		}),
+		nwseResizeIcon: new L.DivIcon({
+			iconSize: new L.Point(8, 8),
+			className: 'leaflet-div-icon leaflet-editing-icon leaflet-edit-resize-nwse'
 		})
 	},
 


### PR DESCRIPTION
When resizing circles or rectangles, the mouse cursor is set to `pointer`, while CSS3 provides better solution - directed arrows known from windows resizing. This change replaces `leaflet-edit-resize` css class with two new: `leaflet-edit-resize-nesw` and `leaflet-edit-resize-nwse` that set the cursor accordingly. Those classes are assigned to the resize markers through Edit.SimpleShape options. 

I haven't changed the name of `resizeIcon` property to `neswResizeIcon` for backward compatibility, but it might make sense to clean it up at future major release.
