### PR TITLE
Prevent skewing on selected edit marker

### DIFF
--- a/dist/leaflet.draw.css
+++ b/dist/leaflet.draw.css
@@ -283,6 +283,7 @@
 	border: 4px dashed rgba(254, 87, 161, 0.6);
 	-webkit-border-radius: 4px;
 	        border-radius: 4px;
+	box-sizing: content-box;
 }
 
 .leaflet-edit-move {


### PR DESCRIPTION
Using `box-sizing: border-box;` is a fairly common pattern these days. Specifically, projects like Bootstrap and Mapbox.js specifically set `box-sizing: border-box;`, which results in the marker being skewed when incorporating them and Leaflet.draw into your project. It would be best to protect against skewed draggable markers by explicitly setting `box-sizing: content-box;`.

Skewed selected edit marker:
![screenshot 2014-11-26 13 28 00](https://cloud.githubusercontent.com/assets/260869/5208302/415595bc-7570-11e4-90de-4d6b9da1509c.png)

Corrected selected edit marker:
![screenshot 2014-11-26 13 28 55](https://cloud.githubusercontent.com/assets/260869/5208307/45b2321e-7570-11e4-9367-dc217b903e16.png)