### PR TITLE
FIXED: Cannot set property 'fill' of undefined

### DIFF
--- a/src/edit/handler/Edit.Poly.js
+++ b/src/edit/handler/Edit.Poly.js
@@ -21,7 +21,7 @@ L.Edit.Poly = L.Handler.extend({
 		var poly = this._poly;
 
 		if (!(poly instanceof L.Polygon)) {
-			poly.options.editing.fill = false;
+			poly.options.fill = false;
 		}
 
 		poly.setStyle(poly.options.editing);


### PR DESCRIPTION
FIXED: Cannot set property 'fill' of undefined
Bug was found when running `examples/edithandlers.html`