### PR TITLE
Bugfix: Make sure that marker appearance changes when in editing mode. 

### DIFF
--- a/spec/suites/EditSpec.js
+++ b/spec/suites/EditSpec.js
@@ -13,7 +13,21 @@ describe("L.Edit", function () {
 			marker.editing.enable();
 		});
 
-		it("Is activated correctly when editing.enable() is called.", function () {});
+		it("Has the leaflet-edit-marker-selected class applied when enabled.", function () {
+			var editingClass = 'leaflet-edit-marker-selected';
+
+			expect(marker.editing.enabled()).to.equal(true);
+			expect(L.DomUtil.hasClass(marker._icon, editingClass)).to.equal(true);
+		});
+
+		it("Lacks the leaflet-edit-marker-selected class when disabled.", function () {
+			var editingClass = 'leaflet-edit-marker-selected';
+
+			marker.editing.disable();
+
+			expect(marker.editing.enabled()).to.equal(false);
+			expect(L.DomUtil.hasClass(marker._icon, editingClass)).to.equal(false);
+		});
 	});
 
 	describe("L.Edit.Circle", function () {

--- a/src/edit/handler/Edit.Marker.js
+++ b/src/edit/handler/Edit.Marker.js
@@ -28,17 +28,17 @@ L.Edit.Marker = L.Handler.extend({
 	},
 
 	_toggleMarkerHighlight: function () {
+		var icon = this._marker._icon;
+
 
 		// Don't do anything if this layer is a marker but doesn't have an icon. Markers
 		// should usually have icons. If using Leaflet.draw with Leafler.markercluster there
 		// is a chance that a marker doesn't.
-		if (!this._icon) {
+		if (!icon) {
 			return;
 		}
 		
 		// This is quite naughty, but I don't see another way of doing it. (short of setting a new icon)
-		var icon = this._icon;
-
 		icon.style.display = 'none';
 
 		if (L.DomUtil.hasClass(icon, 'leaflet-edit-marker-selected')) {


### PR DESCRIPTION
This is a fix for a bug introduced by my changes in https://github.com/Leaflet/Leaflet.draw/pull/323.

Markers were not getting the pink outline in editing mode that indicated that the marker was editable. This was because of an incorrect reference to the marker icon. I was trying to get the `_icon` property of `this`, rather than the `marker`, so `_toggleMarkerHighlight` was exiting early without adding the editing-style class `leaflet-edit-marker-selected`.

I have written a quick bugfix and added two regression tests.

Thanks to @kyletolle, who identified the issue in [a comment on Leaflet.draw pull request #354](https://github.com/Leaflet/Leaflet.draw/pull/354#issuecomment-70327048).