### PR TITLE
Change bower dependencies to allow any 0.7.X Leaflet

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -41,7 +41,7 @@
     "url": "https://github.com/Leaflet/Leaflet.draw.git"
   },
   "dependencies": {
-    "leaflet-dist": "0.7.x"
+    "leaflet": "^0.7.0"
   },
   "devDependencies": {
     "leaflet": "~0.7.0",


### PR DESCRIPTION
Leaflet-dist hasn't been updated in a while and is now unnecessary since Leaflet has fixed their issues with bower.

I'm 99% sure that the semver I used is correct, as it should allow any 0.7.X version of Leaflet, and not anything above 0.7 (like the upcoming 0.8/1.0), as I assume versions outside of 0.7.X may break Leaflet.draw