### PR TITLE
updating bower.son version to match release version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "leaflet-draw",
   "description": "Vector drawing plugin for Leaflet",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "main": [
     "dist/leaflet.draw-src.js",
     "dist/leaflet.draw.css",


### PR DESCRIPTION
revving version to match release version (0.2.3 -> 0.2.4 ).  may be related to: https://github.com/Leaflet/Leaflet.draw/issues/410
