### PR TITLE
Fixed toolbar removal

### DIFF
--- a/src/Control.Draw.js
+++ b/src/Control.Draw.js
@@ -51,10 +51,10 @@ L.Control.Draw = L.Control.extend({
 		return container;
 	},
 
-	onRemove: function () {
+	onRemove: function (map) {
 		for (var toolbarId in this._toolbars) {
 			if (this._toolbars.hasOwnProperty(toolbarId)) {
-				this._toolbars[toolbarId].removeToolbar();
+				map.removeLayer(this._toolbars[toolbarId]);
 			}
 		}
 	},


### PR DESCRIPTION
Fixes #437. It appears the `.removeToolbar()` method no longer exists on the toolbars, so I decided to fall back to just using `map.removeLayer()` as recommended by @manleyjster in the [Leaflet.Toolbar API reference](https://github.com/leaflet/Leaflet.Toolbar/wiki/API-Reference#adding-and-removing-toolbars).