### PR TITLE
Problems with allowIntersection = false for polylines

### DIFF
--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -156,7 +156,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 	},
 
 	_finishShape: function () {
-		var intersects = this._poly.newLatLngIntersects(this._poly.getLatLngs()[0], true);
+		var intersects = this._poly.newLatLngIntersects(this._poly.getLatLngs()[this._poly.getLatLngs().length-1]);
 
 		if ((!this.options.allowIntersection && intersects) || !this._shapeIsValid()) {
 			this._showErrorTooltip();


### PR DESCRIPTION
I have an issue when using the 
`allowIntersection = false` for polylines. In the image below you can see  the error I get.

Looking at the code it seems like the issue comes from when I finish the shape. It then checks the first latlng in the list, which then will be the first point I drew, with the flag` skipFirst = true`. I don't see the meaning of this check? I will then check if the line from the fist point to the last point intersects? 
Which will be true in this case.

One other question is, will I be able to  reach `_finishShape` if I have an intersection?

This fix will solve the issue, it will instead check the last line, and not connecting the first and last point, though this check is already done in `addVertex`. 

I have also read the paper/notes on the sweep line algorithm (http://jeffe.cs.illinois.edu/teaching/373/notes/x06-sweepline.pdf)

Maybe I am missing something important?!

![leaflet-draw-error](https://cloud.githubusercontent.com/assets/2510433/13218640/26a0fe5e-d96b-11e5-960c-090911a11586.png)