### PR TITLE
Check activeMode has not been removed

### DIFF
--- a/src/edit/EditToolbar.js
+++ b/src/edit/EditToolbar.js
@@ -113,7 +113,9 @@ L.EditToolbar = L.Toolbar.extend({
 
 	_save: function () {
 		this._activeMode.handler.save();
-		this._activeMode.handler.disable();
+		if (this._activeMode) {
+			this._activeMode.handler.disable();
+		}
 	},
 
 	_checkDisabled: function () {


### PR DESCRIPTION
On deleting a layer if the edit toolbar has been removed
e.g. https://github.com/Leaflet/Leaflet.draw/issues/315#issuecomment-53139179
then after saving the `_activeMode` is undefined.