### PR TITLE
Length of undefined property _markers at updateGuide

### DIFF
--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -130,7 +130,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 		this._map
 			.off('mouseup', this._onMouseUp, this)
 			.off('mousemove', this._onMouseMove, this)
-			.off('mouseup', this._onMouseUp, this)
+			.off('zoomlevelschange', this._onZoomEnd, this)
 			.off('zoomend', this._onZoomEnd, this)
 			.off('click', this._onTouch, this);
 	},


### PR DESCRIPTION
Fixed a bug where the length of undefined property _markers is tried to be read in the updateGuide function.

This gets triggered when _onZoomEnd is called after a removeHooks call. This normally cannot happen because events which call the _onZoomEnd function are normally removed in the removeHooks call.
However due to what it seems like a copy-paste error, the wrong event was being removed (leaving the zoomlevelschange event which calls _onZoomEnd).

So what happened is: removeHooks is called which deletes the _markers but does not remove the zoomlevelschange event from _map. Then later, a zoomlevelschange event gets triggered which calls _onZoomEnd then _updateGuide which tries to get the length of the (currently deleted) _markers which results in the error we see in the console.