### PR TITLE
Use map distance and not general LatLng distance

### DIFF
--- a/src/draw/handler/Draw.Circle.js
+++ b/src/draw/handler/Draw.Circle.js
@@ -29,10 +29,10 @@ L.Draw.Circle = L.Draw.SimpleShape.extend({
 
 	_drawShape: function (latlng) {
 		if (!this._shape) {
-			this._shape = new L.Circle(this._startLatLng, this._startLatLng.distanceTo(latlng), this.options.shapeOptions);
+			this._shape = new L.Circle(this._startLatLng, this._map.distance(this._startLatLng, latlng), this.options.shapeOptions);
 			this._map.addLayer(this._shape);
 		} else {
-			this._shape.setRadius(this._startLatLng.distanceTo(latlng));
+			this._shape.setRadius(this._map.distance(this._startLatLng, latlng));
 		}
 	},
 


### PR DESCRIPTION
[Leaflet v1.0.0-rc.1+d4ea412]

As [here](https://github.com/Leaflet/Leaflet/issues/1442) the `.distanceTo()` method doesn't take into account the CRS. If the CRS is Simple, like in my case, the interpreted distance from `distanceTo()` makes the radius unnecessary big.

The proposed change should also be porpagated to the PolyLine drawing (the calculation of distances there is completely erroneous when it comes to the Simple CSR).