### PR TITLE
Add polygon.options.metrics to show metric area

### DIFF
--- a/examples/full.html
+++ b/examples/full.html
@@ -65,7 +65,8 @@
 			},
 			draw: {
 				polygon : {
-					allowIntersection: false
+					allowIntersection: false,
+					showArea:true
 				}
 			}
 		}));

--- a/src/draw/handler/Draw.Polygon.js
+++ b/src/draw/handler/Draw.Polygon.js
@@ -16,7 +16,8 @@ L.Draw.Polygon = L.Draw.Polyline.extend({
 			fillColor: null, //same as color by default
 			fillOpacity: 0.2,
 			clickable: true
-		}
+		},
+		metric: true // Whether to use the metric measurement system or imperial
 	},
 
 	initialize: function (map, options) {


### PR DESCRIPTION
Fix showArea functions in metrics during drawing a polygon by adding a metrics options.
Features had been tested in "examples/full.html"