### PR TITLE
fix typo in draw:editresize

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ Triggered as the user moves a rectangle, circle or marker.
 | --- | --- | ---
 | layer | [ILayer](http://leafletjs.com/reference.html#ilayer) | Layer that was just moved.
 
-#### draw:editresized
+#### draw:editresize
 
 Triggered as the user resizes a rectangle or circle.
 


### PR DESCRIPTION
Small typo in documentation: `draw:editresized` should be `draw:editresize`

https://github.com/Leaflet/Leaflet.draw/issues/562