### PR TITLE
Fix allowIntrersection not taken into account when polygon is edited

### DIFF
--- a/src/edit/handler/Edit.Poly.js
+++ b/src/edit/handler/Edit.Poly.js
@@ -235,11 +235,11 @@ L.Edit.PolyVerticesEdit = L.Handler.extend({
 			marker._middleRight.setLatLng(this._getMiddleLatLng(marker, marker._next));
 		}
 
-		if (poly.options.poly) {
+		if (poly.options) {
 			var tooltip = poly._map._editTooltip; // Access the tooltip
 
 			// If we don't allow intersections and the polygon intersects
-			if (!poly.options.poly.allowIntersection && poly.intersects()) {
+			if (!poly.allowIntersection && poly.intersects()) {
 
 				var originalColor = poly.options.color;
 				poly.setStyle({ color: this.options.drawError.color });


### PR DESCRIPTION
Fix allowIntrersection not taken into account when polygon is edited as
_onMarkerDrag was refering to wrong options value