### PR TITLE
Fix draw polygons for mouse events on devices with touch screens - 2

### DIFF
--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -278,16 +278,20 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 			if (Math.abs(distance) < 9 * (window.devicePixelRatio || 1)) {
 				this.addVertex(e.latlng);
 			}
+            
+            this._clickHandled = true;            
 		}
 		this._mouseDownOrigin = null;
 	},
 
 	_onTouch: function (e) {
 		// #TODO: use touchstart and touchend vs using click(touch start & end).
-		if (L.Browser.touch) { // #TODO: get rid of this once leaflet fixes their click/touch.
+		if (L.Browser.touch && !this._clickHandled) { // #TODO: get rid of this once leaflet fixes their click/touch.
 			this._onMouseDown(e);
 			this._onMouseUp(e);
 		}
+        
+        this._clickHandled = null;
 	},
 
 	_onMouseOut: function () {


### PR DESCRIPTION
I created this pull request but it included a change that didn't want to be merged into the original project. https://github.com/Leaflet/Leaflet.draw/pull/636

Undoing the change would have broken my repo and the github.io page liked to it which is useful for testing the fix. Thus I have created a new branch and a new PR.

This PR resolves a few different issues.
https://github.com/Leaflet/Leaflet.draw/issues/631
https://github.com/Leaflet/Leaflet.draw/issues/637
https://github.com/Leaflet/Leaflet.draw/issues/624

This is my github.io page that shows the fix working. https://b3ncr.github.io/docs/examples/full.html