### PR TITLE
drawing fixes for mobile and possibly IE #637

### DIFF
--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -288,7 +288,15 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 		if (this._mouseDownOrigin) {
 			var distance = L.point(clientX, clientY)
 				.distanceTo(this._mouseDownOrigin);
-			if (Math.abs(distance) < 9 * (window.devicePixelRatio || 1)) {
+			var blarg = console.log, lastPtDistance = Infinity;
+			if (this._markers.length > 0) {
+				lastPtDistance = L.point(clientX, clientY).distanceTo(this._markers[this._markers.length - 1]);
+			}
+			blarg('distance to last marker ', lastPtDistance);
+			if (false) {
+				// check for distance to last point
+
+			} else if (Math.abs(distance) < 9 * (window.devicePixelRatio || 1)) {
 				this.addVertex(e.latlng);
 			}
 		}


### PR DESCRIPTION
* for touch screens, if a touch is within a threshold distance of the previous node, it closes the polyline instead of adding a new marker (this prevents the impossible-to-close polygons and polylines we were seeing before)
* prevent double handling of click/touch event when both occur; if click event occurs, flag '_clickHandled' is toggled and prevents touch event from handling the same occurrence.

there seems to be a bug where touchstart events are firing twice on IE desktop which causes misbehavior when drawing, which this PR does not fix. aside from that, i believe this PR may also fix the clockwise drawing bug some have mentioned on IE. all or most of these issues are referenced here: #637 #640 and a few other scattered issues