### PR TITLE
Improve toolbar buttons accesibility

### DIFF
--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -178,14 +178,20 @@ L.Toolbar = L.Class.extend({
 	_createButton: function (options) {
 
 		var link = L.DomUtil.create('a', options.className || '', options.container);
-		link.href = '#';
+		// Screen reader tag
+		var sr = L.DomUtil.create('span', 'sr-only', options.container);
 
-		if (options.text) {
-			link.innerHTML = options.text;
-		}
+		link.href = '#';
+		link.appendChild(sr);
 
 		if (options.title) {
 			link.title = options.title;
+			sr.innerHTML = options.title;
+		}
+
+		if (options.text) {
+			link.innerHTML = options.text;
+			sr.innerHTML = options.text;
 		}
 
 		L.DomEvent

--- a/src/leaflet.draw.css
+++ b/src/leaflet.draw.css
@@ -41,6 +41,17 @@
     text-decoration: none;
 }
 
+.leaflet-draw a .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  border: 0;
+}
+
 /* ================================================================== */
 /* Toolbar actions menu
 /* ================================================================== */


### PR DESCRIPTION
I've came across some accessibility issues in the toolbar. This PR adds a hidden span to allow screen readers read toolbar buttons.

## Steps to reproduce it
- [ ] Install wave chrome extension to check accessibility issues (https://chrome.google.com/webstore/detail/wave-evaluation-tool/jbbplnpkjmmeebjpijfedlgcdilocofh)
- [ ] Run it
- [ ] A bunch of errors should appear (see screenshot)

<img width="620" alt="leaflet" src="https://cloud.githubusercontent.com/assets/381224/21322993/49d873e4-c5fa-11e6-9f35-cd2b57238d2b.png">
