### PR TITLE
bugfix, in touchmode map does not allow to draw Circle or Rectangle

### DIFF
--- a/src/draw/handler/Draw.SimpleShape.js
+++ b/src/draw/handler/Draw.SimpleShape.js
@@ -41,7 +41,10 @@ L.Draw.SimpleShape = L.Draw.Feature.extend({
 			// we should prevent default, otherwise default behavior (scrolling) will fire,
 			// and that will cause document.touchend to fire and will stop the drawing
 			// (circle, rectangle) in touch mode.
-			document.addEventListener('touchstart', L.DomEvent.preventDefault);
+			// (update): we have to send passive now to prevent scroll, because by default it is {passive: true} now, which means,
+			// handler can't event.preventDefault 
+			// check the news https://developers.google.com/web/updates/2016/06/passive-event-listeners
+			document.addEventListener('touchstart', L.DomEvent.preventDefault, {passive: false});
 		}
 	},
 

--- a/src/draw/handler/Draw.SimpleShape.js
+++ b/src/draw/handler/Draw.SimpleShape.js
@@ -66,6 +66,8 @@ L.Draw.SimpleShape = L.Draw.Feature.extend({
 			L.DomEvent.off(document, 'mouseup', this._onMouseUp, this);
 			L.DomEvent.off(document, 'touchend', this._onMouseUp, this);
 
+			document.removeEventListener('touchstart', L.DomEvent.preventDefault);
+
 			// If the box element doesn't exist they must not have moved the mouse, so don't need to destroy/return
 			if (this._shape) {
 				this._map.removeLayer(this._shape);

--- a/src/draw/handler/Draw.SimpleShape.js
+++ b/src/draw/handler/Draw.SimpleShape.js
@@ -37,6 +37,11 @@ L.Draw.SimpleShape = L.Draw.Feature.extend({
 				.on('mousemove', this._onMouseMove, this)
 				.on('touchstart', this._onMouseDown, this)
 				.on('touchmove', this._onMouseMove, this);
+
+			// we should prevent default, otherwise default behavior (scrolling) will fire,
+			// and that will cause document.touchend to fire and will stop the drawing
+			// (circle, rectangle) in touch mode.
+			document.addEventListener('touchstart', L.DomEvent.preventDefault);
 		}
 	},
 


### PR DESCRIPTION
... it stops right after start, when touchend fires.

i am not actually sure why

L.DomEvent.on(document, 'touchstart', L.DomEvent.preventDefault);

is not working, but line below helps

document.addEventListener('touchstart', L.DomEvent.preventDefault);

is that is Leaflet bug which prevents native events assignment, for touch events? Should we create an issue in Leaflet?