### PR TITLE
Handled touch instead of click events in toolbar buttons for iOS.

### DIFF
--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -175,6 +175,13 @@ L.Toolbar = L.Class.extend({
 			.on('disabled', this._handlerDeactivated, this);
 	},
 
+	/* Detect iOS based on browser User Agent, based on:
+	 * http://stackoverflow.com/a/9039885 */
+	_detectIOS: function () {
+		var iOS = (/iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream);
+		return iOS;
+	},
+
 	_createButton: function (options) {
 
 		var link = L.DomUtil.create('a', options.className || '', options.container);
@@ -194,25 +201,31 @@ L.Toolbar = L.Class.extend({
 			sr.innerHTML = options.text;
 		}
 
+		/* iOS does not use click events */
+		var buttonEvent = this._detectIOS() ? 'touchstart' : 'click';
+
 		L.DomEvent
 			.on(link, 'click', L.DomEvent.stopPropagation)
 			.on(link, 'mousedown', L.DomEvent.stopPropagation)
 			.on(link, 'dblclick', L.DomEvent.stopPropagation)
 			.on(link, 'touchstart', L.DomEvent.stopPropagation)
 			.on(link, 'click', L.DomEvent.preventDefault)
-			.on(link, 'click', options.callback, options.context);
+			.on(link, buttonEvent, options.callback, options.context);
 
 		return link;
 	},
 
 	_disposeButton: function (button, callback) {
+		/* iOS does not use click events */
+		var buttonEvent = this._detectIOS() ? 'touchstart' : 'click';
+
 		L.DomEvent
 			.off(button, 'click', L.DomEvent.stopPropagation)
 			.off(button, 'mousedown', L.DomEvent.stopPropagation)
 			.off(button, 'dblclick', L.DomEvent.stopPropagation)
 			.off(button, 'touchstart', L.DomEvent.stopPropagation)
 			.off(button, 'click', L.DomEvent.preventDefault)
-			.off(button, 'click', callback);
+			.off(button, buttonEvent, callback);
 	},
 
 	_handlerActivated: function (e) {


### PR DESCRIPTION
Fix for issue #709, not sure if it's too hacky or not but it worked for me in the following OSes/browsers:

iPad iOS 9.3.5: Safari, Chrome, Firefox
iPhone iOS 10.2: Safari, Chrome, Firefox
macOS 10.12.2: Safari, Chrome, Firefox
Android 5.1: Chrome, Firefox
Windows 7: Chrome, IE11
Windows 10: Edge