### PR TITLE
Fire draw:canceled only when escape key is pressed

### DIFF
--- a/src/draw/handler/Draw.Feature.js
+++ b/src/draw/handler/Draw.Feature.js
@@ -89,8 +89,8 @@ L.Draw.Feature = L.Handler.extend({
 
 	// Cancel drawing when the escape key is pressed
 	_cancelDrawing: function (e) {
-		this._map.fire('draw:canceled', { layerType: this.type });
 		if (e.keyCode === 27) {
+			this._map.fire('draw:canceled', { layerType: this.type });
 			this.disable();
 		}
 	}


### PR DESCRIPTION
In `Draw.Feature.js`, the `_cancelDrawing` callback is passed to the `keyup` event. `fire` is invoked before the keycode is checked, so it's fired for any keypress, instead of only on escape.