### PR TITLE
Hide 'Clear All' button when in layer edit mode (only show in layer delete mode)

### DIFF
--- a/src/edit/EditToolbar.js
+++ b/src/edit/EditToolbar.js
@@ -78,8 +78,8 @@ L.EditToolbar = L.Toolbar.extend({
 
 	// @method getActions(): object
 	// Get actions information
-	getActions: function () {
-		return [
+	getActions: function (handler) {
+		var actions = [
 			{
 				title: L.drawLocal.edit.toolbar.actions.save.title,
 				text: L.drawLocal.edit.toolbar.actions.save.text,
@@ -91,14 +91,19 @@ L.EditToolbar = L.Toolbar.extend({
 				text: L.drawLocal.edit.toolbar.actions.cancel.text,
 				callback: this.disable,
 				context: this
-			},
-			{
-				title: L.drawLocal.edit.toolbar.actions.clearAll.title,
-				text: L.drawLocal.edit.toolbar.actions.clearAll.text,
-				callback: this._clearAllLayers,
-				context: this
 			}
 		];
+
+		if (handler.removeAllLayers) {
+			 actions.push({
+                 title: L.drawLocal.edit.toolbar.actions.clearAll.title,
+                 text: L.drawLocal.edit.toolbar.actions.clearAll.text,
+                 callback: this._clearAllLayers,
+                 context: this
+             });
+		}
+
+		return actions;
 	},
 
 	// @method addToolbar(map): L.DomUtil


### PR DESCRIPTION
Hi,

This fixes a minor bug where the 'Clear All' button is visible when editing layers, e.g. previously
![image](https://user-images.githubusercontent.com/2827949/27753989-f02521e8-5ddf-11e7-8a6b-eadbc327fe7b.png)
so it should be now hidden, e.g.
![image](https://user-images.githubusercontent.com/2827949/27753996-f77e69d6-5ddf-11e7-8a00-606d718242aa.png)

The 'Delete' toolbar still shows the 'Clear All' button:
![image](https://user-images.githubusercontent.com/2827949/27753999-fbc52764-5ddf-11e7-87eb-9a99cbe28002.png)

As an aside, this libary is really neat, thanks for open sourcing it! The drag handles and dotted-line-outlines when you edit a layer are a nice touch. 

Thanks,
Jin