### PR TITLE
Rectangle: added two click draw

### DIFF
--- a/src/draw/handler/Draw.Feature.js
+++ b/src/draw/handler/Draw.Feature.js
@@ -35,7 +35,7 @@ L.Draw.Feature = L.Handler.extend({
 		this._map.fire(L.Draw.Event.DRAWSTART, { layerType: this.type });
 	},
 
-	// @method initialize(): void
+	// @method disable(): void
 	disable: function () {
 		if (!this._enabled) {
 			return;

--- a/src/draw/handler/Draw.Rectangle.js
+++ b/src/draw/handler/Draw.Rectangle.js
@@ -39,18 +39,18 @@ L.Draw.Rectangle = L.Draw.SimpleShape.extend({
 			return;
 		}
 
-		this._twoClicksToggle = false;
+		this._isCurrentlyTwoClickDrawing = false;
 		L.Draw.SimpleShape.prototype.disable.call(this);
 	},
     
 	_onMouseUp: function (e) {
-		if (!this._shape && !this._twoClicksToggle) {
-			this._twoClicksToggle = true;
+		if (!this._shape && !this._isCurrentlyTwoClickDrawing) {
+			this._isCurrentlyTwoClickDrawing = true;
 			return;
 		}
 		
 		// Make sure closing click is on map
-		if (this._twoClicksToggle && !_hasAncestor(e.target, 'leaflet-pane')) {
+		if (this._isCurrentlyTwoClickDrawing && !_hasAncestor(e.target, 'leaflet-pane')) {
 			return;
 		}
 

--- a/src/draw/handler/Draw.Rectangle.js
+++ b/src/draw/handler/Draw.Rectangle.js
@@ -32,7 +32,31 @@ L.Draw.Rectangle = L.Draw.SimpleShape.extend({
 
 		L.Draw.SimpleShape.prototype.initialize.call(this, map, options);
 	},
+    
+	// @method disable(): void
+	disable: function () {
+		if (!this._enabled) {
+			return;
+		}
 
+		this._twoClicksToggle = false;
+		L.Draw.SimpleShape.prototype.disable.call(this);
+	},
+    
+	_onMouseUp: function (e) {
+		if (!this._shape && !this._twoClicksToggle) {
+			this._twoClicksToggle = true;
+			return;
+		}
+		
+		// Make sure closing click is on map
+		if (this._twoClicksToggle && !_hasAncestor(e.target, 'leaflet-pane')) {
+			return;
+		}
+
+		L.Draw.SimpleShape.prototype._onMouseUp.call(this);
+	},
+    
 	_drawShape: function (latlng) {
 		if (!this._shape) {
 			this._shape = new L.Rectangle(new L.LatLngBounds(this._startLatLng, latlng), this.options.shapeOptions);
@@ -65,3 +89,8 @@ L.Draw.Rectangle = L.Draw.SimpleShape.extend({
 		};
 	}
 });
+
+function _hasAncestor (el, cls) {
+	while ((el = el.parentElement) && !el.classList.contains(cls));
+	return el;
+}


### PR DESCRIPTION
Can now draw a rectangle using two clicks (for two opposite corners)
Second click is expected to occur on the map (and not somewhere else on the document / toolbar)