### PR TITLE
Fix Polyline tool for Firefox

### DIFF
--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -289,6 +289,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 		var originalEvent = e.originalEvent;
 		var clientX = originalEvent.clientX;
 		var clientY = originalEvent.clientY;
+		this._startPoint.call(this, clientX, clientY, e);
 		this._endPoint.call(this, clientX, clientY, e);
 		this._clickHandled = null;
 	},


### PR DESCRIPTION
The polyline tool is broken for me (tested on 0.4.8, 0.4.9, 0.4.10) in Firefox. This addition fixes the bug and allows the polyline tool to be used.

Seems to be a regression of the fix to https://github.com/Leaflet/Leaflet.draw/issues/510

Not sure what the best way to add tests for this is, but seems to be working for my use case.  