### PR TITLE
Fix Deprecated Console Output for Leaflet 1.2.0

### DIFF
--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -44,7 +44,17 @@
  * ```
  */
 L.Toolbar = L.Class.extend({
-	includes: [L.Mixin.Events],
+    includes: function() {
+        var version = L.version.split(".");
+
+        //If Version is >= 1.2.0
+        if(parseInt(version[0],10) === 1 && parseInt(version[1],10) >= 2 ) {
+            return L.Events
+        } else {
+            return L.Mixin.Events
+        }
+
+    },
 
 	// @section Methods for modifying the toolbar
 

--- a/src/draw/handler/Draw.Feature.js
+++ b/src/draw/handler/Draw.Feature.js
@@ -5,7 +5,17 @@ L.Draw = L.Draw || {};
  * @aka Draw.Feature
  */
 L.Draw.Feature = L.Handler.extend({
-	includes: L.Mixin.Events,
+    includes: function() {
+        var version = L.version.split(".");
+
+        //If Version is >= 1.2.0
+        if(parseInt(version[0],10) === 1 && parseInt(version[1],10) >= 2 ) {
+            return L.Events
+        } else {
+            return L.Mixin.Events
+        }
+
+    },
 
 	// @method initialize(): void
 	initialize: function (map, options) {

--- a/src/edit/handler/EditToolbar.Delete.js
+++ b/src/edit/handler/EditToolbar.Delete.js
@@ -7,7 +7,17 @@ L.EditToolbar.Delete = L.Handler.extend({
 		TYPE: 'remove' // not delete as delete is reserved in js
 	},
 
-	includes: L.Mixin.Events,
+    includes: function() {
+        var version = L.version.split(".");
+
+        //If Version is >= 1.2.0
+        if(parseInt(version[0],10) === 1 && parseInt(version[1],10) >= 2 ) {
+            return L.Events
+        } else {
+            return L.Mixin.Events
+        }
+
+    },
 
 	// @method intialize(): void
 	initialize: function (map, options) {

--- a/src/edit/handler/EditToolbar.Edit.js
+++ b/src/edit/handler/EditToolbar.Edit.js
@@ -7,7 +7,17 @@ L.EditToolbar.Edit = L.Handler.extend({
 		TYPE: 'edit'
 	},
 
-	includes: L.Mixin.Events,
+    includes: function() {
+		var version = L.version.split(".");
+
+		//If Version is >= 1.2.0
+        if(parseInt(version[0],10) === 1 && parseInt(version[1],10) >= 2 ) {
+        	return L.Events
+		} else {
+            return L.Mixin.Events
+		}
+
+    },
 
 	// @method intialize(): void
 	initialize: function (map, options) {


### PR DESCRIPTION
This fixes the Deptrecated Messages in Leaflet 1.2.0

![bildschirmfoto 2017-08-23 um 13 43 51](https://user-images.githubusercontent.com/3910878/29614138-5a3114fe-8809-11e7-8e44-d22718b87167.png)
