### PR TITLE
Draw Via HTML5 Geolocation / GPS

### DIFF
--- a/build/deps.js
+++ b/build/deps.js
@@ -11,6 +11,7 @@ var deps = {
 		src: [
 			'draw/handler/Draw.Feature.js',
 			'draw/handler/Draw.Polyline.js',
+			'draw/handler/Draw.GPSLine.js',
 			'draw/handler/Draw.Polygon.js',
 			'draw/handler/Draw.SimpleShape.js',
 			'draw/handler/Draw.Rectangle.js',

--- a/dist/images/spritesheet.svg
+++ b/dist/images/spritesheet.svg
@@ -8,9 +8,9 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 600 60"
+   viewBox="0 0 700 60"
    height="60"
-   width="600"
+   width="700"
    id="svg4225"
    version="1.1"
    inkscape:version="0.91 r13725"
@@ -26,12 +26,20 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs4256" />
+     id="defs4256">
+    <inkscape:perspective
+       id="perspective4241"
+       inkscape:persp3d-origin="300 : 20 : 1"
+       inkscape:vp_z="600 : 30 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 30 : 1"
+       sodipodi:type="inkscape:persp3d" />
+  </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -41,15 +49,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1056"
+     inkscape:window-width="1680"
+     inkscape:window-height="980"
      id="namedview4254"
      showgrid="false"
-     inkscape:zoom="1.3101852"
-     inkscape:cx="237.56928"
-     inkscape:cy="7.2419621"
-     inkscape:window-x="1920"
-     inkscape:window-y="24"
+     inkscape:zoom="1"
+     inkscape:cx="219.84092"
+     inkscape:cy="-75.442835"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg4225" />
   <g
@@ -153,4 +161,33 @@
      id="circle-3"
      d="m 581.65725,30 c 0,6.078 -4.926,11 -11,11 -6.074,0 -11,-4.922 -11,-11 0,-6.074 4.926,-11 11,-11 6.074,0 11,4.926 11,11 z"
      inkscape:connector-curvature="0" />
+  <g
+     id="g4251"
+     transform="matrix(0.66959016,0,0,0.609095,199.9832,12.604447)"
+     style="fill:#464646;fill-opacity:1;stroke:#464646;stroke-opacity:1">
+    <path
+       d="m 621.41847,37.031575 1.86721,7.146074 c 28.04323,2.455322 20.87742,-24.960024 -1.86721,-7.146074 z"
+       style="fill:#464646;fill-opacity:1;stroke:#464646;stroke-opacity:1"
+       sodipodi:nodetypes="ccc"
+       id="path2816-7"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 623.29325,18.194709 5.00747,5.444703 c 28.03017,-2.598611 14.18549,-27.0381888 -5.00747,-5.444703 z"
+       style="fill:#464646;fill-opacity:1;stroke:#464646;stroke-opacity:1"
+       sodipodi:nodetypes="ccc"
+       id="path2816"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 624.33383,25.314581 -3.68173,-4.696143 c -13.35275,1.855631 -5.45039,15.134427 3.68173,4.696143 z"
+       style="fill:#464646;fill-opacity:1;stroke:#464646;stroke-opacity:1"
+       sodipodi:nodetypes="ccc"
+       id="path2816-1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 619.99234,44.744772 -2.62881,-5.48029 c -13.46965,-0.562062 -8.22257,14.116708 2.62881,5.48029 z"
+       style="fill:#464646;fill-opacity:1;stroke:#464646;stroke-opacity:1"
+       sodipodi:nodetypes="ccc"
+       id="path2816-1-4"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/src/Leaflet.draw.js
+++ b/src/Leaflet.draw.js
@@ -133,7 +133,7 @@ L.drawLocal = {
 			gpsline: {
 				tooltip: {
 					start: 'Getting GPS location...',
-					loweraccuracy: 'Location results are below required accuracy level.',
+					lowaccuracy	: 'Location results are below required accuracy level.',
 					cont: 'Move to track position or click save to end.',
 					end: 'Move to track position or click save to end.'
 				}

--- a/src/Leaflet.draw.js
+++ b/src/Leaflet.draw.js
@@ -97,6 +97,7 @@ L.drawLocal = {
 				text: 'Delete last point'
 			},
 			buttons: {
+				gpsline: 'Track position',
 				polyline: 'Draw a polyline',
 				polygon: 'Draw a polygon',
 				rectangle: 'Draw a rectangle',
@@ -127,6 +128,14 @@ L.drawLocal = {
 					start: 'Click to start drawing shape.',
 					cont: 'Click to continue drawing shape.',
 					end: 'Click first point to close this shape.'
+				}
+			},
+			gpsline: {
+				tooltip: {
+					start: 'Getting GPS location...',
+					loweraccuracy: 'Location results are below required accuracy level.',
+					cont: 'Move to track position or click save to end.',
+					end: 'Move to track position or click save to end.'
 				}
 			},
 			polyline: {

--- a/src/draw/DrawToolbar.js
+++ b/src/draw/DrawToolbar.js
@@ -9,6 +9,7 @@ L.DrawToolbar = L.Toolbar.extend({
 	},
 
 	options: {
+		gpsline: {},
 		polyline: {},
 		polygon: {},
 		rectangle: {},
@@ -36,6 +37,11 @@ L.DrawToolbar = L.Toolbar.extend({
 	// Get mode handlers information
 	getModeHandlers: function (map) {
 		return [
+			{
+				enabled: this.options.gpsline,
+				handler: new L.Draw.GPSLine(map, this.options.gpsline),
+				title: L.drawLocal.draw.toolbar.buttons.gpsline
+			},
 			{
 				enabled: this.options.polyline,
 				handler: new L.Draw.Polyline(map, this.options.polyline),

--- a/src/draw/handler/Draw.GPSLine.js
+++ b/src/draw/handler/Draw.GPSLine.js
@@ -101,7 +101,7 @@ L.Draw.GPSLine = L.Draw.Feature.extend({
 		.off('locationfound',this._locationfound, this)
 		.off('locationerror',this._locationerror, this);
 
-		map.stopLocate();
+		this._map.stopLocate();
 
 		this._cleanUpShape();
 

--- a/src/draw/handler/Draw.GPSLine.js
+++ b/src/draw/handler/Draw.GPSLine.js
@@ -1,0 +1,243 @@
+/**
+ * @class L.Draw.GPSLine
+ * @aka Draw.GPSLine
+ * @inherits L.Draw.Polyline
+ */
+
+L.Draw.GPSLine = L.Draw.Feature.extend({
+	statics: {
+		TYPE: 'gpsline'
+	},
+
+	Poly: L.Polyline,
+	Marker: L.Marker,
+
+	options: {
+		// Our unique options.
+		minDistance: 5, // Min distance in meters for each point.
+		minAccuracy: 10, // Mininmum accuracy to accept a point.
+		markerIcon: new L.Icon.Default(),
+
+		// All the Location Options from: http://leafletjs.com/reference-1.2.0.html#locate-options
+		watch: true,
+		setView: true,
+		maxZoom: Infinity,
+		timeout: 10000,
+		maximumAge: 0,
+		enableHighAccuracy: false,
+
+		// Plus the same relavant defaults as in Draw.Polyline.js
+		icon: new L.DivIcon({
+			iconSize: new L.Point(8, 8),
+			className: 'leaflet-div-icon leaflet-editing-icon'
+		}),
+		touchIcon: new L.DivIcon({
+			iconSize: new L.Point(20, 20),
+			className: 'leaflet-div-icon leaflet-editing-icon leaflet-touch-icon'
+		}),
+		shapeOptions: {
+			stroke: true,
+			color: '#3388ff',
+			weight: 4,
+			opacity: 0.5,
+			fill: false,
+			clickable: true
+		},
+        zIndexOffset: 2000, // This should be > than the highest z-index any map layers
+
+	},
+
+	// @method initialize(): void
+	initialize: function (map, options) {
+		// if touch, switch to touch icon
+		if (L.Browser.touch) {
+			this.options.icon = this.options.touchIcon;
+		}
+
+		// Save the type so super can fire, need to do this as cannot do this.TYPE :(
+		this.type = L.Draw.GPSLine.TYPE;
+
+		L.Draw.Feature.prototype.initialize.call(this, map, options);
+	},
+
+
+	// @method addHooks(): void
+	// Add listener hooks to this handler
+	addHooks: function () {
+		L.Draw.Feature.prototype.addHooks.call(this);
+		if ( this._map){
+
+			this._markers = [];
+
+			this._markerGroup = new L.LayerGroup();
+			this._map.addLayer(this._markerGroup);
+
+			this._poly = new L.Polyline([], this.options.shapeOptions);
+
+			this._map.
+				locate({
+					watch: this.options.watch,
+					setView: this.options.setView,
+					maxZoom: this.options.maxZoom, 
+					timeout: this.options.timeout,
+					maximumAge: this.options.maximumAge,
+					enableHighAccuracy: this.options.enableHighAccuracy
+				});
+
+			this._map
+				.on('locationfound',this._locationfound, this)
+				.on('mousemove', this._onMouseMove, this)
+				.on('locationerror',this._locationerror, this);
+		}
+	},
+
+	// @method removeHooks(): void
+	// Remove listener hooks from this handler.
+	removeHooks: function () {
+		L.Draw.Feature.prototype.removeHooks.call(this);
+
+		this._map
+		.off('mousemove', this._onMouseMove, this)
+		.off('locationfound',this._locationfound, this)
+		.off('locationerror',this._locationerror, this);
+
+		map.stopLocate();
+
+		this._cleanUpShape();
+
+		// remove markers from map
+		this._map.removeLayer(this._markerGroup);
+		delete this._markerGroup;
+		delete this._markers;
+
+		this._map.removeLayer(this._poly);
+		delete this._poly;
+	},
+
+	// @method addVertex(): void
+	// Add a vertex to the end of the polyline
+	addVertex: function (latlng) {
+		var markersLength = this._markers.length;
+
+		if ( markersLength > 0 ) {
+			var distance_from_old_marker = this._markers[markersLength - 1].getLatLng().distanceTo( latlng );
+			if ( distance_from_old_marker < this.options.minDistance || distance_from_old_marker === 0 ) {
+				return;
+			}
+		}
+
+		this._markers.push(this._createMarker(latlng));
+
+		this._poly.addLatLng(latlng);
+
+		if (this._poly.getLatLngs().length === 2) {
+			this._map.addLayer(this._poly);
+		}
+
+		this._map.fire(L.Draw.Event.DRAWVERTEX, { layers: this._markerGroup });
+	},
+
+	// @method completeShape(): void
+	// Closes the polyline between the first and last points
+	completeShape: function () {
+		if (this._markers.length === 0 ) {
+			return;
+		}
+
+		this._fireCreatedEvent();
+		this.disable();
+
+		if (this.options.repeatMode) {
+			this.enable();
+		}
+	},
+
+	_locationfound: function(e){
+		if ( e.accuracy < this.options.minAccuracy ) {
+			var labelText = {
+				text: L.drawLocal.draw.handlers.gpsline.tooltip.lowaccuracy
+			};
+			this._tooltip.updateContent( labelText );
+			this._tooltip.showAsError();
+			return;
+		}
+
+		this.addVertex(e.latlng);
+		this._getTooltipText();
+	},
+
+	_locationerror: function(e){
+		var labelText = {
+			text: e.message
+		};
+		this._tooltip.updateContent( labelText );
+		this._tooltip.showAsError();
+	},
+
+	/**
+	 * Get the contextual tooltip text.
+	 */
+	_getTooltipText: function(){
+		var labelText;
+
+		if (this._markers.length === 0) {
+			labelText = {
+				text: L.drawLocal.draw.handlers.gpsline.tooltip.start
+			};
+		} else {
+			labelText = {
+				text: L.drawLocal.draw.handlers.gpsline.tooltip.end,
+			};
+		}
+
+		this._tooltip.updateContent(labelText);
+
+		return labelText;
+	},
+
+	_onMouseMove: function (e) {
+		var newPos = this._map.mouseEventToLayerPoint(e.originalEvent);
+		var latlng = this._map.layerPointToLatLng(newPos);
+
+		this._tooltip.updatePosition(latlng);
+
+		L.DomEvent.preventDefault(e.originalEvent);
+	},
+
+
+
+	//*******  Verbatim from Draw.Polyline.js *******/
+
+	_cleanUpShape: function () {
+		if (this._markers.length > 1) {
+			this._markers[this._markers.length - 1].off('click', this._finishShape, this);
+		}
+	},
+
+	_fireCreatedEvent: function () {
+		var latlngs = this._poly.getLatLngs();
+
+		var shape;
+		if ( latlngs.length === 1 ) {
+			shape = new this.Marker( latlngs[0], {
+					icon: this.options.markerIcon,
+					zIndexOffset: this.options.zIndexOffset
+			});
+		} else {
+			shape = new this.Poly(latlngs, this.options.shapeOptions);
+		}
+		L.Draw.Feature.prototype._fireCreatedEvent.call(this, shape);
+	},
+
+	_createMarker: function (latlng) {
+		var marker = new L.Marker(latlng, {
+			icon: this.options.icon,
+			zIndexOffset: this.options.zIndexOffset * 2
+		});
+
+		this._markerGroup.addLayer(marker);
+
+		return marker;
+	}
+
+});

--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -368,7 +368,11 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 		var markerCount = this._markers.length;
 		// The last marker should have a click handler to close the polyline
 		if (markerCount > 1) {
-			this._markers[markerCount - 1].on('click', this._finishShape, this);
+			setTimeout(
+			function(){
+				this._markers[this._markers.length - 1].on('click', this._finishShape, this);
+			}.bind(this),
+			250);
 		}
 
 		// Remove the old marker click handler (as only the last point should close the polyline)

--- a/src/images/spritesheet.svg
+++ b/src/images/spritesheet.svg
@@ -8,9 +8,9 @@
    xmlns:xlink="http://www.w3.org/1999/xlink"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   viewBox="0 0 600 60"
+   viewBox="0 0 700 60"
    height="60"
-   width="600"
+   width="700"
    id="svg4225"
    version="1.1"
    inkscape:version="0.91 r13725"
@@ -26,12 +26,20 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title />
+        <dc:title></dc:title>
       </cc:Work>
     </rdf:RDF>
   </metadata>
   <defs
-     id="defs4256" />
+     id="defs4256">
+    <inkscape:perspective
+       id="perspective4241"
+       inkscape:persp3d-origin="300 : 20 : 1"
+       inkscape:vp_z="600 : 30 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 30 : 1"
+       sodipodi:type="inkscape:persp3d" />
+  </defs>
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -41,15 +49,15 @@
      guidetolerance="10"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:window-width="1920"
-     inkscape:window-height="1056"
+     inkscape:window-width="1680"
+     inkscape:window-height="980"
      id="namedview4254"
      showgrid="false"
-     inkscape:zoom="1.3101852"
-     inkscape:cx="237.56928"
-     inkscape:cy="7.2419621"
-     inkscape:window-x="1920"
-     inkscape:window-y="24"
+     inkscape:zoom="1"
+     inkscape:cx="219.84092"
+     inkscape:cy="-75.442835"
+     inkscape:window-x="0"
+     inkscape:window-y="1"
      inkscape:window-maximized="1"
      inkscape:current-layer="svg4225" />
   <g
@@ -153,4 +161,33 @@
      id="circle-3"
      d="m 581.65725,30 c 0,6.078 -4.926,11 -11,11 -6.074,0 -11,-4.922 -11,-11 0,-6.074 4.926,-11 11,-11 6.074,0 11,4.926 11,11 z"
      inkscape:connector-curvature="0" />
+  <g
+     id="g4251"
+     transform="matrix(0.66959016,0,0,0.609095,199.9832,12.604447)"
+     style="fill:#464646;fill-opacity:1;stroke:#464646;stroke-opacity:1">
+    <path
+       d="m 621.41847,37.031575 1.86721,7.146074 c 28.04323,2.455322 20.87742,-24.960024 -1.86721,-7.146074 z"
+       style="fill:#464646;fill-opacity:1;stroke:#464646;stroke-opacity:1"
+       sodipodi:nodetypes="ccc"
+       id="path2816-7"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 623.29325,18.194709 5.00747,5.444703 c 28.03017,-2.598611 14.18549,-27.0381888 -5.00747,-5.444703 z"
+       style="fill:#464646;fill-opacity:1;stroke:#464646;stroke-opacity:1"
+       sodipodi:nodetypes="ccc"
+       id="path2816"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 624.33383,25.314581 -3.68173,-4.696143 c -13.35275,1.855631 -5.45039,15.134427 3.68173,4.696143 z"
+       style="fill:#464646;fill-opacity:1;stroke:#464646;stroke-opacity:1"
+       sodipodi:nodetypes="ccc"
+       id="path2816-1"
+       inkscape:connector-curvature="0" />
+    <path
+       d="m 619.99234,44.744772 -2.62881,-5.48029 c -13.46965,-0.562062 -8.22257,14.116708 2.62881,5.48029 z"
+       style="fill:#464646;fill-opacity:1;stroke:#464646;stroke-opacity:1"
+       sodipodi:nodetypes="ccc"
+       id="path2816-1-4"
+       inkscape:connector-curvature="0" />
+  </g>
 </svg>

--- a/src/leaflet.draw.css
+++ b/src/leaflet.draw.css
@@ -26,7 +26,7 @@
     background-image: url('images/spritesheet.png');
     background-image: linear-gradient(transparent, transparent), url('images/spritesheet.svg');
     background-repeat: no-repeat;
-    background-size: 300px 30px;
+    background-size: 350px 30px;
     background-clip: padding-box;
 }
 
@@ -148,6 +148,14 @@
 /* ================================================================== */
 /* Draw toolbar
 /* ================================================================== */
+
+.leaflet-draw-toolbar .leaflet-draw-draw-gpsline {
+    background-position: -296px -2px;
+}
+
+.leaflet-touch .leaflet-draw-toolbar .leaflet-draw-draw-gpsline {
+    background-position: -294px -1px;
+}
 
 .leaflet-draw-toolbar .leaflet-draw-draw-polyline {
     background-position: -2px -2px;


### PR DESCRIPTION
I'm submitting a pull request with a new drawing tool I'm calling "GPSLine". It's similar to Polyline in that a line is typically created, but instead of drawing the initial input, the line is drawn via HTML5 Geolocation results. 

<img width="418" alt="screen shot 2017-09-26 at 1 51 58 am" src="https://user-images.githubusercontent.com/16576/30846685-48ddab80-a25e-11e7-8222-4d24d21b4f56.png">

After the line has been saved it can be cleaned up via the Leaflet.draw editing tools like any other polyline. 

Demo here: 
https://jsfiddle.net/a41L91hf/

If you're testing this from a laptop and not in the field, you can use Chrome's debug tools to spoof your GPS location. In the three-dots menu indicated, enable the Sensors tab and set the coordinates you'd like to use there. 
<img width="1269" alt="screen shot 2017-09-26 at 1 50 33 am" src="https://user-images.githubusercontent.com/16576/30846709-54729226-a25e-11e7-8949-06b58f34d71b.png">

Features: 
- Create geometry using your device's location information.
- Edit collected location information to clean it up.
- In the case that only a single point is created, a marker icon is created instead of a polyline. 
- Uses tooltip error mode to alert user to geolocation errors.
- Specify a minimum distance or minimum accuracy to reduce the number of spurious points collected.

