### PR TITLE
Add/remove className options when PolyVerticesEdit is enabled/disabled

### DIFF
--- a/src/edit/handler/Edit.Poly.js
+++ b/src/edit/handler/Edit.Poly.js
@@ -130,11 +130,25 @@ L.Edit.PolyVerticesEdit = L.Handler.extend({
 	// Add listener hooks to this handler.
 	addHooks: function () {
 		var poly = this._poly;
+		var path = poly._path;
 
 		if (!(poly instanceof L.Polygon)) {
 			poly.options.fill = false;
 			if (poly.options.editing) {
 				poly.options.editing.fill = false;
+			}
+		}
+
+		if (path) {
+			if (poly.options.editing.className) {
+				if (poly.options.original.className) {
+					poly.options.original.className.split(' ').forEach(function(className) {
+						L.DomUtil.removeClass(path, className);
+					});
+				}
+				poly.options.editing.className.split(' ').forEach(function(className) {
+					L.DomUtil.addClass(path, className);
+				});
 			}
 		}
 
@@ -155,6 +169,20 @@ L.Edit.PolyVerticesEdit = L.Handler.extend({
 	// Remove listener hooks from this handler.
 	removeHooks: function () {
 		var poly = this._poly;
+		var path = poly._path;
+
+		if (path) {
+			if (poly.options.editing.className) {
+				poly.options.editing.className.split(' ').forEach(function(className) {
+					L.DomUtil.removeClass(path, className);
+				});
+				if (poly.options.original.className) {
+					poly.options.original.className.split(' ').forEach(function(className) {
+						L.DomUtil.addClass(path, className);
+					});
+				}
+			}
+		}
 
 		poly.setStyle(poly.options.original);
 


### PR DESCRIPTION
Leaflet's `setStyle` method ignores `className`, by design (see Leaflet/Leaflet#2662).

So instead, manually add and remove the class names when the `PolyVerticesEdit` handler is enabled and disabled.