### PR TITLE
Support showing polyline distance if enabled

### DIFF
--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -470,9 +470,6 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 	_getTooltipText: function () {
 		var showLength = this.options.showLength,
 			labelText, distanceStr;
-		if (L.Browser.touch) {
-			showLength = false; // if there's a better place to put this, feel free to move it
-		}
 		if (this._markers.length === 0) {
 			labelText = {
 				text: L.drawLocal.draw.handlers.polyline.tooltip.start


### PR DESCRIPTION
As discussed in https://github.com/Leaflet/Leaflet/issues/5266 , modern web browsers like Chrome/Chromium/Opera support touch events. Thus, L.Browser.touch returns true even on non-touch screens. In any case, the _getTooltipText should display the distance if showLength is set to true. Without this change, showLength is broken in many browsers for Polyline.