### PR TITLE
Move showRadius property from RectangleOptions to CircleOptions in the docs.

### DIFF
--- a/build/docs-misc.leafdoc
+++ b/build/docs-misc.leafdoc
@@ -81,7 +81,6 @@ for this section of the documentation, please edit docs-misc.leafdoc in the buil
 | --- | --- | --- | ---
 | shapeOptions | [Leaflet Path options](http://leafletjs.com/reference.html#path-options) | [See code](https://github.com/Leaflet/Leaflet.draw/blob/master/src/draw/handler/Draw.Rectangle.js#L7) | The options used when drawing the rectangle on the map.
 | repeatMode | Bool | `false` | Determines if the draw tool remains enabled after drawing a shape.
-| showRadius | Bool | `true` | Show the area of the drawn circle in m², ha or km². **The area is only approximate and become less accurate the larger the circle is.**
 
 @namespace CircleOptions
 
@@ -89,6 +88,7 @@ for this section of the documentation, please edit docs-misc.leafdoc in the buil
 | --- | --- | --- | ---
 | shapeOptions | [Leaflet Path options](http://leafletjs.com/reference.html#path-options) | [See code](https://github.com/Leaflet/Leaflet.draw/blob/master/src/draw/handler/Draw.Circle.js#L7) | The options used when drawing the circle on the map.
 | repeatMode | Bool | `false` | Determines if the draw tool remains enabled after drawing a shape.
+| showRadius | Bool | `true` | Show the area of the drawn circle in m², ha or km². **The area is only approximate and become less accurate the larger the circle is.**
 
 
 @namespace MarkerOptions

--- a/docs/leaflet-draw-latest.html
+++ b/docs/leaflet-draw-latest.html
@@ -2271,12 +2271,6 @@ for this section of the documentation, please edit docs-misc.leafdoc in the buil
 <td><code>false</code></td>
 <td>Determines if the draw tool remains enabled after drawing a shape.</td>
 </tr>
-<tr>
-<td>showRadius</td>
-<td>Bool</td>
-<td><code>true</code></td>
-<td>Show the area of the drawn circle in m², ha or km². <strong>The area is only approximate and become less accurate the larger the circle is.</strong></td>
-</tr>
 </tbody>
 </table>
 
@@ -2301,6 +2295,12 @@ for this section of the documentation, please edit docs-misc.leafdoc in the buil
 <td>Bool</td>
 <td><code>false</code></td>
 <td>Determines if the draw tool remains enabled after drawing a shape.</td>
+</tr>
+<tr>
+<td>showRadius</td>
+<td>Bool</td>
+<td><code>true</code></td>
+<td>Show the area of the drawn circle in m², ha or km². <strong>The area is only approximate and become less accurate the larger the circle is.</strong></td>
 </tr>
 </tbody>
 </table>

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,11 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "1.0.1": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/1.0.1/-/1.0.1-1.0.0.tgz",
-      "integrity": "sha1-789KKTiYkqYfqRLSbmu+4ViuhGk="
-    },
     "abbrev": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.9.tgz",


### PR DESCRIPTION
The showRadius property appears to have been erroneously documented as being a property of RectangleOptions instead of CircleOptions. 