### PR TITLE
Bugfix #851 - Duplicate Listener in Edit.Circle

### DIFF
--- a/src/edit/handler/Edit.Circle.js
+++ b/src/edit/handler/Edit.Circle.js
@@ -54,16 +54,4 @@ L.Circle.addInitHook(function () {
 			this.editing.enable();
 		}
 	}
-
-	this.on('add', function () {
-		if (this.editing && this.editing.enabled()) {
-			this.editing.addHooks();
-		}
-	});
-
-	this.on('remove', function () {
-		if (this.editing && this.editing.enabled()) {
-			this.editing.removeHooks();
-		}
-	});
 });


### PR DESCRIPTION
The previous bugfix does not solve the problem, it just hides it.
addHooks() and removeHooks() were called two times because Edit.Circle and parent class Edit.CircleMarker installed the same listener for add and remove.