### PR TITLE
Moved 'showArea' out of 'shapeOptions'

### DIFF
--- a/src/draw/handler/Draw.Rectangle.js
+++ b/src/draw/handler/Draw.Rectangle.js
@@ -17,9 +17,9 @@ L.Draw.Rectangle = L.Draw.SimpleShape.extend({
 			fill: true,
 			fillColor: null, //same as color by default
 			fillOpacity: 0.2,
-			showArea: true,
 			clickable: true
 		},
+		showArea: true, //Whether to show the area in the tooltip
 		metric: true // Whether to use the metric measurement system or imperial
 	},
 


### PR DESCRIPTION
The 'showArea' option is inside 'shapeOptions' object of L.Draw.Rectangle.
In method _getTooltipText, line 82: ``showArea = this.options.showArea``
When drawing a rectangle, its area is not shown, because the option is not where expected.