### PR TITLE
Fix include of events mixin in prototype

### DIFF
--- a/spec/suites/DrawFeatureSpec.js
+++ b/spec/suites/DrawFeatureSpec.js
@@ -1,0 +1,9 @@
+describe("Draw.Feature", function () {
+	it("initHook", function () {
+		var hook = sinon.spy();
+		L.Draw.Feature.addInitHook(hook);
+		var map = L.map(document.createElement('div'));
+		var marker = new L.Draw.Marker(map);
+		expect(hook.calledOnce).to.eql(true);
+	});
+});

--- a/spec/suites/EditToolbar.js
+++ b/spec/suites/EditToolbar.js
@@ -1,0 +1,17 @@
+describe("EditToolbar", function () {
+	it("Edit.initHook", function () {
+		var hook = sinon.spy();
+		L.EditToolbar.Edit.addInitHook(hook);
+		var map = L.map(document.createElement('div'));
+		var toolbar = new L.EditToolbar.Edit(map, { featureGroup: L.featureGroup() });
+		expect(hook.calledOnce).to.eql(true);
+	});
+
+	it("Delete.initHook", function () {
+		var hook = sinon.spy();
+		L.EditToolbar.Delete.addInitHook(hook);
+		var map = L.map(document.createElement('div'));
+		var toolbar = new L.EditToolbar.Delete(map, { featureGroup: L.featureGroup() });
+		expect(hook.calledOnce).to.eql(true);
+	});
+});

--- a/spec/suites/Toolbar.js
+++ b/spec/suites/Toolbar.js
@@ -1,0 +1,8 @@
+describe("Toolbar", function () {
+	it("initHook", function () {
+		var hook = sinon.spy();
+		L.Toolbar.addInitHook(hook);
+		var toolbar = new L.Toolbar();
+		expect(hook.calledOnce).to.eql(true);
+	});
+});

--- a/src/Leaflet.draw.js
+++ b/src/Leaflet.draw.js
@@ -46,7 +46,17 @@ L.drawVersion = '0.4.2';
  * or GeometryCollection. If you need to add multigeometry features to the draw plugin, convert them to a
  * FeatureCollection of non-multigeometries (Points, LineStrings, or Polygons).
  */
-L.Draw = {};
+L.Draw = {
+	EventsMixin: (function() {
+		var version = L.version.split(".");
+		//If Version is < 1.2.0
+		if (parseInt(version[0], 10) < 1 || (parseInt(version[0], 10) === 1 && parseInt(version[1], 10) < 2)) {
+			return L.Mixin.Events;
+		} else {
+			return L.Evented.prototype;
+		}
+	})(),
+};
 
 /**
  * @class L.drawLocal

--- a/src/Toolbar.js
+++ b/src/Toolbar.js
@@ -44,6 +44,8 @@
  * ```
  */
 L.Toolbar = L.Class.extend({
+	includes: [L.Draw.EventsMixin],
+	
 	// @section Methods for modifying the toolbar
 
 	// @method initialize(options): void
@@ -54,14 +56,6 @@ L.Toolbar = L.Class.extend({
 		this._modes = {};
 		this._actionButtons = [];
 		this._activeMode = null;
-
-		var version = L.version.split('.');
-		//If Version is >= 1.2.0
-		if (parseInt(version[0], 10) === 1 && parseInt(version[1], 10) >= 2) {
-			L.Toolbar.include(L.Evented.prototype);
-		} else {
-			L.Toolbar.include(L.Mixin.Events);
-		}
 	},
 
 	// @method enabled(): boolean

--- a/src/draw/handler/Draw.Feature.js
+++ b/src/draw/handler/Draw.Feature.js
@@ -5,7 +5,8 @@ L.Draw = L.Draw || {};
  * @aka Draw.Feature
  */
 L.Draw.Feature = L.Handler.extend({
-
+	includes: [L.Draw.EventsMixin],
+	
 	// @method initialize(): void
 	initialize: function (map, options) {
 		this._map = map;
@@ -18,14 +19,6 @@ L.Draw.Feature = L.Handler.extend({
 			options.shapeOptions = L.Util.extend({}, this.options.shapeOptions, options.shapeOptions);
 		}
 		L.setOptions(this, options);
-
-		var version = L.version.split('.');
-		//If Version is >= 1.2.0
-		if (parseInt(version[0], 10) === 1 && parseInt(version[1], 10) >= 2) {
-			L.Draw.Feature.include(L.Evented.prototype);
-		} else {
-			L.Draw.Feature.include(L.Mixin.Events);
-		}
 	},
 
 	// @method enable(): void

--- a/src/edit/handler/EditToolbar.Delete.js
+++ b/src/edit/handler/EditToolbar.Delete.js
@@ -6,6 +6,8 @@ L.EditToolbar.Delete = L.Handler.extend({
 	statics: {
 		TYPE: 'remove' // not delete as delete is reserved in js
 	},
+	
+	includes: [L.Draw.EventsMixin],
 
 	// @method intialize(): void
 	initialize: function (map, options) {
@@ -22,15 +24,6 @@ L.EditToolbar.Delete = L.Handler.extend({
 
 		// Save the type so super can fire, need to do this as cannot do this.TYPE :(
 		this.type = L.EditToolbar.Delete.TYPE;
-
-		var version = L.version.split('.');
-		//If Version is >= 1.2.0
-		if (parseInt(version[0], 10) === 1 && parseInt(version[1], 10) >= 2) {
-			L.EditToolbar.Delete.include(L.Evented.prototype);
-		} else {
-			L.EditToolbar.Delete.include(L.Mixin.Events);
-		}
-
 	},
 
 	// @method enable(): void

--- a/src/edit/handler/EditToolbar.Edit.js
+++ b/src/edit/handler/EditToolbar.Edit.js
@@ -6,6 +6,8 @@ L.EditToolbar.Edit = L.Handler.extend({
 	statics: {
 		TYPE: 'edit'
 	},
+	
+	includes: [L.Draw.EventsMixin],
 
 	// @method intialize(): void
 	initialize: function (map, options) {
@@ -24,14 +26,6 @@ L.EditToolbar.Edit = L.Handler.extend({
 
 		// Save the type so super can fire, need to do this as cannot do this.TYPE :(
 		this.type = L.EditToolbar.Edit.TYPE;
-
-		var version = L.version.split('.');
-		//If Version is >= 1.2.0
-		if (parseInt(version[0], 10) === 1 && parseInt(version[1], 10) >= 2) {
-			L.EditToolbar.Edit.include(L.Evented.prototype);
-		} else {
-			L.EditToolbar.Edit.include(L.Mixin.Events);
-		}
 	},
 
 	// @method enable(): void


### PR DESCRIPTION
Fixes #857 

Not sure if `L.Draw.EventsMixin` it the correct place, but I wanted to change the check on the version to a single place instead of repeating it in multiple places.