### PR TITLE
Update EditToolbar.Edit.js due to dragging undefined on removelayer during edit

### DIFF
--- a/src/edit/handler/EditToolbar.Edit.js
+++ b/src/edit/handler/EditToolbar.Edit.js
@@ -255,7 +255,7 @@ L.EditToolbar.Edit = L.Handler.extend({
 		}
 
 		if (layer instanceof L.Marker) {
-			layer.dragging.disable();
+			if (layer.dragging){layer.dragging.disable();}
 			layer
 				.off('dragend', this._onMarkerDragEnd, this)
 				.off('touchmove', this._onTouchMove, this)


### PR DESCRIPTION
After Leaflet v1.01 (issue #5295), when removing marker during edit, dragging is first disable/delete by Leaflet (Marker.js) and then by leaflet draw. So layer.dragging is undefined. 
=> I added a verification on dragging existence. Edit.Marker.js has to be modified too in removeHooks()