### PR TITLE
Fire enabled before enabling

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-safari-launcher": "~1.0.0",
     "leafdoc": "^1.4.0",
-    "leaflet": "^1.0.1",
+    "leaflet": "1.0.1",
     "mocha": "^3.5.3",
     "phantomjs-prebuilt": "^2.1.16",
     "prosthetic-hand": "^1.3.1",

--- a/src/draw/handler/Draw.Feature.js
+++ b/src/draw/handler/Draw.Feature.js
@@ -35,9 +35,9 @@ L.Draw.Feature = L.Handler.extend({
 			return;
 		}
 
-		L.Handler.prototype.enable.call(this);
-
 		this.fire('enabled', {handler: this.type});
+
+		L.Handler.prototype.enable.call(this);
 
 		this._map.fire(L.Draw.Event.DRAWSTART, {layerType: this.type});
 	},


### PR DESCRIPTION
Fixes #844
Firing 'enabled' allows the previous activeMode handler to clean up before enabling this handler.
The issue was:
- Enable Draw Rectangle ->  map is draggable? if yes, disable dragging while we make a rectangle
- Enable Draw Circle -> map is draggable? NO (it has just been disabled). leave disabled.
- Fire 'enabled' -> Disable Draw Rectangle, re-enable map dragging

Now draw circle has been enabled on a draggable map, so it won't work properly