### PR TITLE
Fixed issue of finishing a polygon/polyline still allowing intersection.

### DIFF
--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -214,7 +214,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 
 	_finishShape: function () {
 		var latlngs = this._poly._defaultShape ? this._poly._defaultShape() : this._poly.getLatLngs();
-		var intersects = this._poly.newLatLngIntersects(latlngs[latlngs.length - 1]);
+		var intersects = this._poly.newLatLngIntersects(latlngs[0]);
 
 		if ((!this.options.allowIntersection && intersects) || !this._shapeIsValid()) {
 			this._showErrorTooltip();


### PR DESCRIPTION
When you click the start point to finish a polyline or polygon, intersections are allowed even if it has been set to false. I changed the logic to check the start point, instead of the last previous point when finishing the given polyline or polygon. 

If anything looks out of place or needs changed, just let me know or feel free to change however you see fit.