### PR TITLE
Add movestart and moveend events for shapes

### DIFF
--- a/src/edit/handler/Edit.Poly.js
+++ b/src/edit/handler/Edit.Poly.js
@@ -255,6 +255,7 @@ L.Edit.PolyVerticesEdit = L.Handler.extend({
 
 	_onMarkerDragStart: function () {
 		this._poly.fire('editstart');
+		this._poly.fire('movestart');
 	},
 
 	_spliceLatLngs: function () {
@@ -287,6 +288,7 @@ L.Edit.PolyVerticesEdit = L.Handler.extend({
 	_fireEdit: function () {
 		this._poly.edited = true;
 		this._poly.fire('edit');
+		this._poly.fire('moveend');
 		this._poly._map.fire(L.Draw.Event.EDITVERTEX, {layers: this._markerGroup, poly: this._poly});
 	},
 
@@ -446,6 +448,7 @@ L.Edit.PolyVerticesEdit = L.Handler.extend({
 			this._updatePrevNext(marker, marker2);
 
 			this._poly.fire('editstart');
+			this._poly.fire('movestart');
 		};
 
 		onDragEnd = function () {

--- a/src/edit/handler/Edit.SimpleShape.js
+++ b/src/edit/handler/Edit.SimpleShape.js
@@ -146,6 +146,7 @@ L.Edit.SimpleShape = L.Handler.extend({
 		marker.setOpacity(0);
 
 		this._shape.fire('editstart');
+		this._shape.fire('movestart');
 	},
 
 	_fireEdit: function () {
@@ -172,6 +173,8 @@ L.Edit.SimpleShape = L.Handler.extend({
 		marker.setOpacity(1);
 
 		this._fireEdit();
+
+		this._shape.fire('moveend');
 	},
 
 	_onTouchStart: function (e) {
@@ -192,6 +195,7 @@ L.Edit.SimpleShape = L.Handler.extend({
 		}
 
 		this._shape.fire('editstart');
+		this._shape.fire('movestart');
 	},
 
 	_onTouchMove: function (e) {


### PR DESCRIPTION
Hi,

First of all, thanks so much for this amazing lib, it rocks! 🤘 We're using it within a product we're building in my company.

I'm opening this PR because I've found the need of these changes in a specific use case we have, in which we need to:

- _close_ the shape popup when users **start** resizing/moving
- _re-open_ the shape popup when users **end** resizing/moving

(FYI we open the popup when the shape is created).

Any suggestion, comment, or request for changes is welcome in order to merge.

Thanks! 🍺 