### PR TITLE
Check if last segment intersects other lines.

### DIFF
--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -214,7 +214,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 
 	_finishShape: function () {
 		var latlngs = this._poly._defaultShape ? this._poly._defaultShape() : this._poly.getLatLngs();
-		var intersects = this._poly.newLatLngIntersects(latlngs[latlngs.length - 1]);
+		var intersects = this._poly.newLatLngIntersects(latlngs[0]);
 
 		if ((!this.options.allowIntersection && intersects) || !this._shapeIsValid()) {
 			this._showErrorTooltip();

--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -214,9 +214,14 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 
 	_finishShape: function () {
 		var latlngs = this._poly._defaultShape ? this._poly._defaultShape() : this._poly.getLatLngs();
-		var intersects = this._poly.newLatLngIntersects(latlngs[0]);
+		var intersects = this._poly.newLatLngIntersects(latlngs[latlngs.length - 1]);
 
 		if ((!this.options.allowIntersection && intersects) || !this._shapeIsValid()) {
+			this._showErrorTooltip();
+			return;
+		}
+
+		if (this._poly._checkLastSegment()) {
 			this._showErrorTooltip();
 			return;
 		}

--- a/src/ext/Polyline.Intersect.js
+++ b/src/ext/Polyline.Intersect.js
@@ -102,5 +102,21 @@ L.Polyline.include({
 			points.push(this._map.latLngToLayerPoint(_shape[i]));
 		}
 		return points;
+	},
+
+	_checkLastSegment: function(){
+		var points = this._getProjectedPoints(),
+			length = points.length - 1,
+			p = points[length],
+			p1 = points[0];
+
+		for (var i = 1; i < length - 1; i++) {
+			if (L.LineUtil.segmentsIntersect(p, p1, points[i], points[i + 1])) {
+				return true;
+			}
+		}
+
+		return false;
 	}
+
 });


### PR DESCRIPTION
Currently, the last segment is allowed to intersect other lines due to how the check is performed when finishing a polygon/polyline. Added logic to check if this has occurred when attempting to finish a polygon/polyline.