### PR TITLE
workaround for #789 (Can only draw two-point polygons in Chrome w/ Touch)

### DIFF
--- a/src/draw/handler/Draw.Polygon.js
+++ b/src/draw/handler/Draw.Polygon.js
@@ -46,7 +46,7 @@ L.Draw.Polygon = L.Draw.Polyline.extend({
 
 		// The first marker should have a click handler to close the polygon
 		if (markerCount === 1) {
-			this._markers[0].on('click', this._finishShape, this);
+			//this._markers[0].on('click', this._finishShape, this); // workaround for https://github.com/Leaflet/Leaflet.draw/issues/789
 		}
 
 		// Add and update the double click handler

--- a/src/draw/handler/Draw.Polyline.js
+++ b/src/draw/handler/Draw.Polyline.js
@@ -368,7 +368,7 @@ L.Draw.Polyline = L.Draw.Feature.extend({
 		var markerCount = this._markers.length;
 		// The last marker should have a click handler to close the polyline
 		if (markerCount > 1) {
-			this._markers[markerCount - 1].on('click', this._finishShape, this);
+			//this._markers[markerCount - 1].on('click', this._finishShape, this); // workaround for https://github.com/Leaflet/Leaflet.draw/issues/789
 		}
 
 		// Remove the old marker click handler (as only the last point should close the polyline)


### PR DESCRIPTION
Although the source of the issue is somewhere deeper, it seems that just
commenting out these 2 lines is enough to solve it.

I observe no functionality loss with this change, perhaps the code was redundant
for some unclear reason.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/leaflet/leaflet.draw/926)
<!-- Reviewable:end -->
