### PR TITLE
It fix a typo in L.Draw.Event example

### DIFF
--- a/docs/leaflet-draw-0.4.14.html
+++ b/docs/leaflet-draw-0.4.14.html
@@ -279,7 +279,7 @@ markers. It also turns off the ability to edit layers.</p>
 
 
 
-<pre><code class="lang-js">map.on(L.Draw.Event.CREATED; function (e) {
+<pre><code class="lang-js">map.on(L.Draw.Event.CREATED, function (e) {
    var type = e.layerType,
        layer = e.layer;
    if (type === &#39;marker&#39;) {


### PR DESCRIPTION
i think on this part => `map.on(L.Draw.Event.CREATED; function (e) {` should be something like that `map.on(L.Draw.Event.CREATED, function (e) {`. what do u think?