### PR TITLE
Prevents calling setStyle with undefined argument

### DIFF
--- a/src/edit/handler/Edit.Poly.js
+++ b/src/edit/handler/Edit.Poly.js
@@ -183,7 +183,9 @@ L.Edit.PolyVerticesEdit = L.Handler.extend({
 			}
 		}
 
-		poly.setStyle(poly.options.original);
+		if (poly.options.original) {
+			poly.setStyle(poly.options.original);
+		}
 
 		if (poly._map) {
 			poly._map.removeLayer(this._markerGroup);

--- a/src/edit/handler/Edit.Poly.js
+++ b/src/edit/handler/Edit.Poly.js
@@ -149,7 +149,9 @@ L.Edit.PolyVerticesEdit = L.Handler.extend({
 			}
 		}
 
-		poly.setStyle(poly.options.editing);
+		if (poly.options.editing) {
+			poly.setStyle(poly.options.editing);
+		}
 
 		if (this._poly._map) {
 


### PR DESCRIPTION
Fixes the following error
```
TypeError: Cannot read property 'hasOwnProperty' of undefined
    at NewClass.setStyle (leaflet-src.js?9eb7:7853)
    at NewClass.removeHooks (leaflet.draw-src.js?2c0f:1967)
    at eval (leaflet.draw-src.js?2c0f:1833)
    at NewClass._eachVertexHandler (leaflet.draw-src.js?2c0f:1816)
    at NewClass.removeHooks (leaflet.draw-src.js?2c0f:1832)
    at NewClass.eval (leaflet.draw-src.js?2c0f:2302)
    at NewClass.fire (leaflet-src.js?9eb7:593)
    at NewClass.removeLayer (leaflet-src.js?9eb7:6681)
    at NewClass.removeLayer (leaflet-src.js?9eb7:6823)
    at NewClass.removeLayer (leaflet-src.js?9eb7:6969)
```