### PR TITLE
Declare undeclared var

### DIFF
--- a/src/ext/GeometryUtil.js
+++ b/src/ext/GeometryUtil.js
@@ -70,7 +70,7 @@
 
 			if (isMetric) {
 				units = ['ha', 'm'];
-				type = typeof isMetric;
+				var type = typeof isMetric;
 				if (type === 'string') {
 					units = [isMetric];
 				} else if (type !== 'boolean') {


### PR DESCRIPTION
When I use Leaflet.draw I sometime get the error: 
`ReferenceError: assignment to undeclared variable typeleaflet.draw-src.js:3161:11`
Variables had to be declared: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Undeclared_var

This PR fixed my issue.