### PR TITLE
Fix L.LeafletEvent Incorrect Return Key

### DIFF
--- a/src/edit/handler/EditToolbar.Delete.js
+++ b/src/edit/handler/EditToolbar.Delete.js
@@ -113,7 +113,7 @@ L.EditToolbar.Delete = L.Handler.extend({
 	// @method save(): void
 	// Save deleted layers
 	save: function () {
-		this._map.fire(L.Draw.Event.DELETED, {layers: this._deletedLayers});
+		this._map.fire(L.Draw.Event.DELETED, {layer: this._deletedLayers});
 	},
 
 	// @method removeAllLayers(): void


### PR DESCRIPTION
Traditionally, all L.LeafletEvent returns layer(s) as an array - but has kept the name to e.layer. Save function appears to be the only degenerate case and breaks TypeScript checks for project that uses L.LeafletDraw Types.

Additionally, it homogenise the naming convention of such event returns.