### PR TITLE
Fix undeclared variable type in function readableArea

### DIFF
--- a/src/ext/GeometryUtil.js
+++ b/src/ext/GeometryUtil.js
@@ -65,6 +65,7 @@
 		// The value will be rounded as defined by the precision option object.
 		readableArea: function (area, isMetric, precision) {
 			var areaStr,
+				type,
 				units,
 				precision = L.Util.extend({}, defaultPrecision, precision);
 


### PR DESCRIPTION
When I compile leaflet.draw with Google Closure Compiler, this exception appear:

ReferenceError: assignment to undeclared variable type
    readableArea ontomanticsui-map.min.js:64792
    _getTooltipText ontomanticsui-map.min.js:63900
    _onMouseMove ontomanticsui-map.min.js:63843
    fire ontomanticsui-map.min.js:1114
    _touchEvent ontomanticsui-map.min.js:64658
    _onTouchMove ontomanticsui-map.min.js:64692