### PR TITLE
Fix "TypeError: cannot call leaflet_pos on undefined" when this._mapPane is undefined

### DIFF
--- a/docs/examples-0.7.x/libs/leaflet-src.js
+++ b/docs/examples-0.7.x/libs/leaflet-src.js
@@ -2260,7 +2260,7 @@ L.Map = L.Class.extend({
 	// private methods for getting map state
 
 	_getMapPanePos: function () {
-		return L.DomUtil.getPosition(this._mapPane);
+		return this._mapPane ? L.DomUtil.getPosition(this._mapPane) : new Point(0, 0);
 	},
 
 	_moved: function () {

--- a/docs/examples/libs/leaflet-src.js
+++ b/docs/examples/libs/leaflet-src.js
@@ -4375,7 +4375,7 @@ var Map = Evented.extend({
 	// private methods for getting map state
 
 	_getMapPanePos: function () {
-		return getPosition(this._mapPane) || new Point(0, 0);
+		return this._mapPane ? getPosition(this._mapPane) : new Point(0, 0);
 	},
 
 	_moved: function () {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "karma-phantomjs-launcher": "^1.0.2",
     "karma-safari-launcher": "~1.0.0",
     "leafdoc": "^1.4.0",
-    "leaflet": "^1.0.1",
+    "leaflet": "1.0.3",
     "mocha": "^3.5.3",
     "phantomjs-prebuilt": "^2.1.16",
     "prosthetic-hand": "^1.3.1",


### PR DESCRIPTION
Added check when this._mapPane is null and causes leaflet_pos undefined on getPosition