### PR TITLE
Add startDraw to Draw.Rectangle

### DIFF
--- a/src/draw/handler/Draw.Rectangle.js
+++ b/src/draw/handler/Draw.Rectangle.js
@@ -43,6 +43,20 @@ L.Draw.Rectangle = L.Draw.SimpleShape.extend({
 		L.Draw.SimpleShape.prototype.disable.call(this);
 	},
 
+	// @method startDraw(): void
+	startDraw: function (latlng) {
+		if (this._isDrawing) {
+			return;
+		}
+
+		this._isDrawing = true;
+		this._startLatLng = latlng;
+
+		L.DomEvent
+			.on(document, 'mouseup', this._onMouseUp, this)
+			.on(document, 'touchend', this._onMouseUp, this)
+	},
+
 	_onMouseUp: function (e) {
 		if (!this._shape && !this._isCurrentlyTwoClickDrawing) {
 			this._isCurrentlyTwoClickDrawing = true;


### PR DESCRIPTION
I needed to skip first click event of drawing a rectangle, because i wanted to start drawing from the maps right click event. I added a "startDraw" function to Draw.Rectangle, so i could do that. It's pretty much the _onMouseDown event of Draw.SimpleShape copy pasted. This works great on my machine, hope it work for others aswell.

Here is how i use it:
```
map.on('contextmenu', function(event) {
	let rectangle = new L.Draw.Rectangle(map, {
		shapeOptions: {
			color: '#3388ff',
			fillColor: '#3388ff',
			weight: 3,
			opacity: 1,
			fillOpacity: 0.2,
		},
		showArea: false
	});
        rectangle.enable();
	rectangle.startDraw(event.latlng);
});
```