### PR TITLE
Use preferred tile.openstreetmap.org URL

### DIFF
--- a/docs/examples-0.7.x/basic.html
+++ b/docs/examples-0.7.x/basic.html
@@ -53,7 +53,7 @@
 <div id="map" style="width: 800px; height: 600px; border: 1px solid #ccc"></div>
 <button id="changeColor">Rectangle -> Blue</button>
 <script>
-    var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
             osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
             osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
             map = new L.Map('map', {layers: [osm], center: new L.LatLng(-37.7772, 175.2756), zoom: 15});

--- a/docs/examples-0.7.x/edithandlers.html
+++ b/docs/examples-0.7.x/edithandlers.html
@@ -24,7 +24,7 @@
 	<div id="map" style="width: 800px; height: 600px; border: 1px solid #ccc"></div>
 
 	<script>
-		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 			map = new L.Map('map', {layers: [osm], center: new L.LatLng(51.505, -0.04), zoom: 13});

--- a/docs/examples-0.7.x/full.html
+++ b/docs/examples-0.7.x/full.html
@@ -48,7 +48,7 @@
 <div id="map" style="width: 800px; height: 600px; border: 1px solid #ccc"></div>
 
 <script>
-    var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
             osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
             osm = L.tileLayer(osmUrl, { maxZoom: 18, attribution: osmAttrib }),
             map = new L.Map('map', { center: new L.LatLng(51.505, -0.04), zoom: 13 }),

--- a/docs/examples-0.7.x/snapping.html
+++ b/docs/examples-0.7.x/snapping.html
@@ -52,7 +52,7 @@
 	<div id="map" style="width: 800px; height: 600px; border: 1px solid #ccc"></div>
 	<button id="changeColor">Rectangle -> Blue</button>
 	<script>
-		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
 			map = new L.Map('map', {layers: [osm], center: new L.LatLng(48.48988, 1.39638), zoom: 14 });

--- a/docs/examples/basic.html
+++ b/docs/examples/basic.html
@@ -53,7 +53,7 @@
 <div id="map" style="width: 800px; height: 600px; border: 1px solid #ccc"></div>
 <button id="changeColor">Rectangle -> Blue</button>
 <script>
-    var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
             osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
             osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
             map = new L.Map('map', {layers: [osm], center: new L.LatLng(-37.7772, 175.2756), zoom: 15});

--- a/docs/examples/edithandlers.html
+++ b/docs/examples/edithandlers.html
@@ -24,7 +24,7 @@
 	<div id="map" style="width: 800px; height: 600px; border: 1px solid #ccc"></div>
 
 	<script>
-		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib});
 			map = new L.Map('map', {layers: [osm], center: new L.LatLng(51.505, -0.04), zoom: 13});

--- a/docs/examples/full.html
+++ b/docs/examples/full.html
@@ -48,7 +48,7 @@
 <div id="map" style="width: 800px; height: 600px; border: 1px solid #ccc"></div>
 
 <script>
-    var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+    var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
             osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
             osm = L.tileLayer(osmUrl, { maxZoom: 18, attribution: osmAttrib }),
             map = new L.Map('map', { center: new L.LatLng(51.505, -0.04), zoom: 13 }),

--- a/docs/examples/libs/leaflet-src.js
+++ b/docs/examples/libs/leaflet-src.js
@@ -11348,7 +11348,7 @@ function gridLayer(options) {
  * @example
  *
  * ```js
- * L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}', {foo: 'bar'}).addTo(map);
+ * L.tileLayer('https://tile.openstreetmap.org/{z}/{x}/{y}.png?{foo}', {foo: 'bar'}).addTo(map);
  * ```
  *
  * @section URL template

--- a/docs/examples/popup.html
+++ b/docs/examples/popup.html
@@ -49,7 +49,7 @@
     <div id="map" style="width: 800px; height: 600px; border: 1px solid #ccc"></div>
 
     <script>
-        var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+        var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
             osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
             osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
             map = new L.Map('map', {center: new L.LatLng(29.9792, 31.1344), zoom: 15}),

--- a/docs/examples/snapping.html
+++ b/docs/examples/snapping.html
@@ -52,7 +52,7 @@
 	<div id="map" style="width: 800px; height: 600px; border: 1px solid #ccc"></div>
 	<button id="changeColor">Rectangle -> Blue</button>
 	<script>
-		var osmUrl = 'http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png',
+		var osmUrl = 'https://tile.openstreetmap.org/{z}/{x}/{y}.png',
 			osmAttrib = '&copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors',
 			osm = L.tileLayer(osmUrl, {maxZoom: 18, attribution: osmAttrib}),
 			map = new L.Map('map', {layers: [osm], center: new L.LatLng(48.48988, 1.39638), zoom: 14 });


### PR DESCRIPTION
Fixing preferred URL for tile.openstreetmap.org
The `a|b|c` aliases are no longer required now that we support HTTP/2 + HTTP/3.

Signed-off-by: Grant Slater <git@firefishy.com>