### PR TITLE
geometryUtil readableDistance expects first param to be number, wheraes here the string was passed

### DIFF
--- a/src/draw/handler/Draw.Circle.js
+++ b/src/draw/handler/Draw.Circle.js
@@ -67,7 +67,7 @@ L.Draw.Circle = L.Draw.SimpleShape.extend({
 			this._drawShape(latlng);
 
 			// Get the new radius (rounded to 1 dp)
-			radius = this._shape.getRadius().toFixed(1);
+			radius = parseFloat(this._shape.getRadius().toFixed(1));
 
 			var subtext = '';
 			if (showRadius) {


### PR DESCRIPTION
geometryUtil readableDistance expects first param to be a number, wheraes here the string was passed.
<img width="721" alt="Leaflet GeometryUtil 2024-04-25 11-57-03" src="https://github.com/Leaflet/Leaflet.draw/assets/1250998/90c98d12-ec7b-48ae-866d-a6596b287e79">

https://github.com/makinacorpus/Leaflet.GeometryUtil/blob/master/src/leaflet.geometryutil.js#L67

This was causing an error 
```
leaflet.geometryutil.js:70 Uncaught TypeError: distance.toFixed is not a function
```

<img width="667" alt="2024-04-25 11-54-38" src="https://github.com/Leaflet/Leaflet.draw/assets/1250998/2047904d-9396-4279-98cb-aceb73c63ed0">


After this fix the error is gone
